### PR TITLE
Add frontmatter metadata to specification documents

### DIFF
--- a/spec/cli.md
+++ b/spec/cli.md
@@ -1,3 +1,8 @@
+---
+title: CLI Specification
+description: Mica ツールチェーンのコマンドラインインターフェース仕様。プロジェクト操作、依存関係管理、開発ツールのコマンドを定義。
+---
+
 # Mica CLI Specification
 
 This document defines the command-line interface for the Mica toolchain.

--- a/spec/debugger.md
+++ b/spec/debugger.md
@@ -1,3 +1,8 @@
+---
+title: Debugger Specification
+description: TUI デバッガーの仕様。ブレークポイント、ステップ実行、変数検査、コールスタック確認機能を提供。
+---
+
 # Mica Debugger Specification
 
 This document defines the TUI debugger for the Mica language.

--- a/spec/jit.md
+++ b/spec/jit.md
@@ -1,3 +1,8 @@
+---
+title: JIT Specification
+description: JIT コンパイルと実行時最適化機能の仕様。Tier 0 インタプリタと Tier 1 ベースライン JIT の2段階実行モデル。
+---
+
 # Mica JIT Specification
 
 This document defines the JIT compilation and runtime optimization features.

--- a/spec/language.md
+++ b/spec/language.md
@@ -1,3 +1,8 @@
+---
+title: Language Specification
+description: Mica プログラミング言語の構文とセマンティクス。型システム、制御フロー、並行処理、例外処理を定義。
+---
+
 # Mica Language Specification
 
 This document defines the syntax and semantics of the Mica programming language.

--- a/spec/lsp.md
+++ b/spec/lsp.md
@@ -1,3 +1,8 @@
+---
+title: LSP Specification
+description: Language Server Protocol による IDE 統合機能の仕様。診断、補完、定義ジャンプ、ホバー情報などをサポート。
+---
+
 # Mica LSP Specification
 
 This document defines the Language Server Protocol support for the Mica language.

--- a/spec/package.md
+++ b/spec/package.md
@@ -1,3 +1,8 @@
+---
+title: Package System Specification
+description: パッケージ管理システムの仕様。プロジェクト構造、依存関係解決、ロックファイルによる再現可能ビルドを定義。
+---
+
 # Mica Package System Specification
 
 This document defines the package management system for Mica projects.

--- a/spec/vm.md
+++ b/spec/vm.md
@@ -1,3 +1,8 @@
+---
+title: VM Specification
+description: 仮想マシンアーキテクチャの仕様。バイトコード命令セット、64ビットタグ付き値表現、Mark-Sweep GC を定義。
+---
+
 # Mica VM Specification
 
 This document defines the Virtual Machine architecture including bytecode, value representation, and garbage collection.


### PR DESCRIPTION
## Summary
Added YAML frontmatter headers to all specification documents in the `spec/` directory. This enables better document organization and metadata support for documentation systems (such as static site generators or documentation platforms).

## Changes
- **spec/cli.md**: Added frontmatter with title and Japanese description for CLI specification
- **spec/debugger.md**: Added frontmatter with title and Japanese description for debugger specification
- **spec/jit.md**: Added frontmatter with title and Japanese description for JIT specification
- **spec/language.md**: Added frontmatter with title and Japanese description for language specification
- **spec/lsp.md**: Added frontmatter with title and Japanese description for LSP specification
- **spec/package.md**: Added frontmatter with title and Japanese description for package system specification
- **spec/vm.md**: Added frontmatter with title and Japanese description for VM specification

## Details
Each specification document now includes:
- `title`: English title of the specification
- `description`: Japanese description summarizing the specification's scope and key features

This metadata will improve discoverability and provide better context when these documents are processed by documentation tools or displayed in documentation portals.