### PR TITLE
Add optional JIT compilation feature flag

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,6 +3,10 @@ name = "mica"
 version = "0.1.0"
 edition = "2024"
 
+[features]
+default = []
+jit = []
+
 [dependencies]
 clap = { version = "4.5.54", features = ["derive"] }
 toml = "0.8"

--- a/src/jit/mod.rs
+++ b/src/jit/mod.rs
@@ -6,8 +6,11 @@
 //! - AArch64 instruction encoding
 //! - Template-based bytecode compiler
 //! - Stack maps for GC integration
+//!
+//! This module is only compiled when the `jit` feature is enabled.
+//! Use `cargo build --features jit` to include JIT support.
 
-// JIT is not yet integrated into the main VM, allow dead code
+// JIT is not yet fully integrated into the main VM, allow dead code
 #![allow(dead_code)]
 
 pub mod aarch64;

--- a/src/main.rs
+++ b/src/main.rs
@@ -4,6 +4,7 @@ use std::process::ExitCode;
 
 mod compiler;
 mod debugger;
+#[cfg(feature = "jit")]
 mod jit;
 mod lsp;
 mod package;


### PR DESCRIPTION
## Summary
This PR introduces an optional `jit` feature flag to make JIT compilation support opt-in rather than always-on. The JIT module is now only compiled when explicitly enabled via `cargo build --features jit`.

## Key Changes
- **Cargo.toml**: Added `[features]` section with a new `jit` feature flag (disabled by default)
- **src/main.rs**: Wrapped JIT module declaration with `#[cfg(feature = "jit")]` to conditionally compile the module
- **src/jit/mod.rs**: Updated documentation to clarify that the module is only compiled with the `jit` feature enabled
- **src/vm/vm.rs**: Updated all JIT-related conditional compilation from `#[cfg(target_arch = "aarch64")]` to `#[cfg(all(target_arch = "aarch64", feature = "jit"))]` to require both the correct architecture AND the feature flag
  - Updated struct field conditionals
  - Updated method conditionals for `jit_compile_function()` and `is_jit_compiled()`
  - Updated runtime JIT compilation logic with improved error messages
  - Updated documentation comments to reflect the new requirement

## Implementation Details
- The JIT feature is now properly gated behind both an architecture check (AArch64) and an explicit feature flag
- Users must explicitly opt-in with `cargo build --features jit` to include JIT support
- Non-AArch64 platforms or builds without the feature flag will log "JIT not available" instead of "not on AArch64" for better clarity
- All conditional compilation is consistent across the codebase