### PR TITLE
Remove StringLen and StringConcat opcodes

### DIFF
--- a/src/compiler/dump.rs
+++ b/src/compiler/dump.rs
@@ -1352,10 +1352,6 @@ impl<'a> Disassembler<'a> {
                     .push_str(&format!("SetFieldCached {}, {} ; .{}", idx, cache, field));
             }
 
-            // String operations
-            Op::StringLen => self.output.push_str("StringLen"),
-            Op::StringConcat => self.output.push_str("StringConcat"),
-
             // Type operations
             Op::TypeOf => self.output.push_str("TypeOf"),
             Op::ToString => self.output.push_str("ToString"),

--- a/src/vm/bytecode.rs
+++ b/src/vm/bytecode.rs
@@ -288,8 +288,6 @@ const OP_ARRAY_SET: u8 = 49;
 const OP_ARRAY_PUSH: u8 = 50;
 const OP_ARRAY_POP: u8 = 51;
 const OP_ARRAY_GET_INT: u8 = 52;
-const OP_STRING_LEN: u8 = 53;
-const OP_STRING_CONCAT: u8 = 54;
 const OP_TYPE_OF: u8 = 55;
 const OP_TO_STRING: u8 = 56;
 const OP_PARSE_INT: u8 = 57;
@@ -407,8 +405,6 @@ fn write_op<W: Write>(w: &mut W, op: &Op) -> io::Result<()> {
         Op::ArrayPush => w.write_all(&[OP_ARRAY_PUSH])?,
         Op::ArrayPop => w.write_all(&[OP_ARRAY_POP])?,
         Op::ArrayGetInt => w.write_all(&[OP_ARRAY_GET_INT])?,
-        Op::StringLen => w.write_all(&[OP_STRING_LEN])?,
-        Op::StringConcat => w.write_all(&[OP_STRING_CONCAT])?,
         Op::TypeOf => w.write_all(&[OP_TYPE_OF])?,
         Op::ToString => w.write_all(&[OP_TO_STRING])?,
         Op::ParseInt => w.write_all(&[OP_PARSE_INT])?,
@@ -503,8 +499,6 @@ fn read_op<R: Read>(r: &mut R) -> Result<Op, BytecodeError> {
         OP_ARRAY_PUSH => Op::ArrayPush,
         OP_ARRAY_POP => Op::ArrayPop,
         OP_ARRAY_GET_INT => Op::ArrayGetInt,
-        OP_STRING_LEN => Op::StringLen,
-        OP_STRING_CONCAT => Op::StringConcat,
         OP_TYPE_OF => Op::TypeOf,
         OP_TO_STRING => Op::ToString,
         OP_PARSE_INT => Op::ParseInt,
@@ -787,8 +781,6 @@ mod tests {
             Op::ArrayPush,
             Op::ArrayPop,
             Op::ArrayGetInt,
-            Op::StringLen,
-            Op::StringConcat,
             Op::TypeOf,
             Op::ToString,
             Op::ParseInt,

--- a/src/vm/ops.rs
+++ b/src/vm/ops.rs
@@ -110,12 +110,6 @@ pub enum Op {
     ArrayGetInt, // Quickened: Array access with int index
 
     // ========================================
-    // Extension: String operations (not in v0 core)
-    // ========================================
-    StringLen,
-    StringConcat,
-
-    // ========================================
     // Extension: Type operations
     // ========================================
     TypeOf,   // Push type name as string

--- a/src/vm/verifier.rs
+++ b/src/vm/verifier.rs
@@ -412,10 +412,6 @@ impl Verifier {
             Op::ArrayPop => (1, 1),  // pops array, pushes value
             Op::ArrayGetInt => (2, 1),
 
-            // String operations
-            Op::StringLen => (1, 1),
-            Op::StringConcat => (2, 1),
-
             // Type operations
             Op::TypeOf => (1, 1),
             Op::ToString => (1, 1),

--- a/src/vm/vm.rs
+++ b/src/vm/vm.rs
@@ -881,24 +881,6 @@ impl VM {
 
                 obj.fields.insert(field_name, value);
             }
-            Op::StringLen => {
-                let s = self.stack.pop().ok_or("stack underflow")?;
-                let r = s.as_ref().ok_or("runtime error: expected string")?;
-                let obj = self.heap.get(r).ok_or("runtime error: invalid reference")?;
-                let s = obj.as_string().ok_or("runtime error: expected string")?;
-                self.stack.push(Value::I64(s.value.chars().count() as i64));
-            }
-            Op::StringConcat => {
-                let b = self.stack.pop().ok_or("stack underflow")?;
-                let a = self.stack.pop().ok_or("stack underflow")?;
-
-                let a_str = self.value_to_string(&a)?;
-                let b_str = self.value_to_string(&b)?;
-
-                let result = format!("{}{}", a_str, b_str);
-                let r = self.heap.alloc_string(result)?;
-                self.stack.push(Value::Ref(r));
-            }
             Op::TypeOf => {
                 let value = self.stack.pop().ok_or("stack underflow")?;
                 let type_name = match &value {
@@ -1776,8 +1758,9 @@ mod tests {
 
     #[test]
     fn test_string_operations() {
+        // Test string concatenation using Op::Add
         let stack = run_code_with_strings(
-            vec![Op::PushString(0), Op::PushString(1), Op::StringConcat],
+            vec![Op::PushString(0), Op::PushString(1), Op::Add],
             vec!["Hello, ".to_string(), "World!".to_string()],
         )
         .unwrap();


### PR DESCRIPTION
## Summary
Remove the `StringLen` and `StringConcat` opcodes from the VM, consolidating string operations to use existing opcodes instead.

## Changes
- **Removed opcodes**: `StringLen` and `StringConcat` from the `Op` enum in `src/vm/ops.rs`
- **Updated bytecode handling**: Removed opcode constants (`OP_STRING_LEN`, `OP_STRING_CONCAT`) and their serialization/deserialization logic in `src/vm/bytecode.rs`
- **Updated VM execution**: Removed `StringLen` and `StringConcat` case handlers from the VM interpreter in `src/vm/vm.rs`
- **Updated verification**: Removed stack effect rules for the removed opcodes in `src/vm/verifier.rs`
- **Updated disassembler**: Removed output formatting for the removed opcodes in `src/compiler/dump.rs`
- **Updated tests**: Modified string operation test to use `Op::Add` instead of `Op::StringConcat` for string concatenation

## Implementation Details
String concatenation now uses the existing `Op::Add` opcode, which handles both numeric addition and string concatenation based on operand types. This reduces opcode duplication and simplifies the instruction set while maintaining the same functionality.

https://claude.ai/code/session_01DAjLFmAP5PXsrRdYNE4ert