### PR TITLE
fix(ci): update existing coverage comment instead of creating new one

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -148,7 +148,7 @@ jobs:
             });
 
             const botComment = comments.find(c =>
-              c.user.type === 'Bot' && c.body.includes('## Coverage Report')
+              c.user.login === 'github-actions[bot]' && c.body.includes('## 📊 Coverage Report')
             );
 
             if (botComment) {


### PR DESCRIPTION
## Summary
- Fix bot comment detection to use `user.login === 'github-actions[bot]'` instead of `user.type === 'Bot'`
- Also match the exact header `## 📊 Coverage Report`

This ensures existing coverage comments are updated rather than creating duplicates on each push.

## Test plan
- [ ] Push to this PR and verify comment is updated, not duplicated

🤖 Generated with [Claude Code](https://claude.com/claude-code)