### PR TITLE
Remove Array type, consolidate to Slots for all array operations

### DIFF
--- a/src/vm/vm.rs
+++ b/src/vm/vm.rs
@@ -713,9 +713,7 @@ impl VM {
                     .ok_or("runtime error: expected array or string")?;
                 let obj = self.heap.get(r).ok_or("runtime error: invalid reference")?;
 
-                let len = if let Some(arr) = obj.as_array() {
-                    arr.elements.len() as i64
-                } else if let Some(s) = obj.as_string() {
+                let len = if let Some(s) = obj.as_string() {
                     s.value.chars().count() as i64
                 } else if let Some(slots) = obj.as_slots() {
                     // For fixed arrays (Slots), slot[0] contains the length
@@ -805,7 +803,6 @@ impl VM {
                         if let Some(obj) = self.heap.get(*r) {
                             match obj.obj_type() {
                                 super::ObjectType::String => "string",
-                                super::ObjectType::Array => "array",
                                 super::ObjectType::Object => "object",
                                 super::ObjectType::Slots => "array", // Slots is used for arrays and vectors
                             }
@@ -1265,13 +1262,6 @@ impl VM {
                     .ok_or("runtime error: invalid reference")?;
                 match obj {
                     super::HeapObject::String(s) => Ok(s.value.clone()),
-                    super::HeapObject::Array(a) => {
-                        let mut parts = Vec::new();
-                        for elem in &a.elements {
-                            parts.push(self.value_to_string(elem)?);
-                        }
-                        Ok(format!("[{}]", parts.join(", ")))
-                    }
                     super::HeapObject::Object(o) => {
                         let mut parts = Vec::new();
                         for (k, v) in &o.fields {


### PR DESCRIPTION
## Summary
This PR removes the dedicated `MocaArray` heap object type and consolidates all array functionality to use the `Slots` type instead. This simplifies the heap object model by eliminating redundant array representation.

## Key Changes
- Removed `ObjectType::Array` enum variant
- Removed `MocaArray` struct and `HeapObject::Array` variant
- Removed `Heap::alloc_array()` method
- Removed `as_array()` and `as_array_mut()` accessor methods
- Updated `HeapObject::obj_type()`, `header()`, `header_mut()`, and `trace()` to remove Array handling
- Updated VM's `LEN` opcode to check for strings and slots instead of arrays
- Updated VM's `TYPEOF` opcode to remove Array type check
- Updated VM's `value_to_string()` to remove Array formatting
- Updated heap size calculation to remove Array accounting
- Migrated `test_alloc_array` to `test_gc_traces_slots` to verify GC tracing works with Slots

## Implementation Details
- The `Slots` type (slot-based heap object) now serves as the unified representation for all array-like collections
- This reduces code duplication and simplifies the heap object matching logic throughout the codebase
- All existing array functionality is preserved through the Slots implementation

https://claude.ai/code/session_01ViJgN82ak4D7TUqk3GDHTF