### PR TITLE
ci: remove coverage threshold check from CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,13 +20,10 @@ jobs:
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable
         with:
-          components: rustfmt, clippy, llvm-tools-preview
+          components: rustfmt, clippy
 
       - name: Install just
         uses: extractions/setup-just@v2
-
-      - name: Install cargo-llvm-cov
-        uses: taiki-e/install-action@cargo-llvm-cov
 
       - name: Cache cargo
         uses: actions/cache@v4

--- a/Justfile
+++ b/Justfile
@@ -3,8 +3,8 @@
 # Default task: run all checks
 default: check
 
-# Run all checks (fmt, clippy, test, coverage)
-check: fmt-check clippy test coverage-check
+# Run all checks (fmt, clippy, test)
+check: fmt-check clippy test
     @echo "All checks passed!"
 
 # Format check (doesn't modify files)


### PR DESCRIPTION
## Summary
- CIのcoverage 75%閾値チェックを削除
- `just check`から`coverage-check`を除外
- PRへのcoverage reportコメント機能は維持

## Test plan
- [ ] CIが正常に動作することを確認
- [ ] PRにcoverage reportがコメントされることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)