### PR TITLE
ci: add performance-report job to GitHub Actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -163,3 +163,140 @@ jobs:
                 body: body,
               });
             }
+
+  performance-report:
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Cache cargo
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/bin/
+            ~/.cargo/registry/index/
+            ~/.cargo/registry/cache/
+            ~/.cargo/git/db/
+            target/
+          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+
+      - name: Build moca (release)
+        run: cargo build --release
+
+      - name: Build bench tool
+        run: cargo build --release -p bench
+
+      - name: Run benchmark on PR branch
+        run: |
+          ./target/release/bench ./target/release/moca > pr_bench.json
+          cat pr_bench.json
+
+      - name: Get main branch benchmark
+        run: |
+          git stash || true
+          git checkout ${{ github.base_ref }}
+          cargo build --release
+          ./target/release/bench ./target/release/moca > main_bench.json
+          cat main_bench.json
+          git checkout ${{ github.head_ref }}
+          git stash pop || true
+
+      - name: Generate performance report
+        run: |
+          cat > generate_report.py << 'PYTHON_SCRIPT'
+          import json
+          import sys
+
+          with open('pr_bench.json') as f:
+              pr_data = json.load(f)
+
+          with open('main_bench.json') as f:
+              main_data = json.load(f)
+
+          main_times = {r['name']: r['moca_time_secs'] for r in main_data['results']}
+
+          lines = []
+          lines.append("| Benchmark | Current | Rust | Main |")
+          lines.append("|-----------|---------|------|------|")
+
+          for result in pr_data['results']:
+              name = result['name']
+              current = result['moca_time_secs']
+              rust = result['rust_time_secs']
+              main = main_times.get(name, current)
+
+              # Calculate Rust comparison (how many times faster)
+              if rust > 0:
+                  rust_ratio = current / rust
+                  rust_str = f"{rust:.3f}s ({rust_ratio:.0f}x faster)"
+              else:
+                  rust_str = f"{rust:.3f}s"
+
+              # Calculate main comparison (percentage change)
+              if main > 0:
+                  pct_change = ((main - current) / main) * 100
+                  if pct_change > 5:
+                      icon = "🟢"
+                      sign = "+"
+                  elif pct_change < -5:
+                      icon = "🔴"
+                      sign = ""
+                  else:
+                      icon = "🟡"
+                      sign = "+" if pct_change >= 0 else ""
+                  main_str = f"{main:.3f}s {icon} {sign}{pct_change:.0f}%"
+              else:
+                  main_str = "N/A"
+
+              lines.append(f"| {name} | {current:.3f}s | {rust_str} | {main_str} |")
+
+          lines.append("")
+          lines.append("Legend: 🟢 >5% faster, 🟡 ±5%, 🔴 >5% slower (vs main)")
+
+          print('\n'.join(lines))
+          PYTHON_SCRIPT
+
+          python3 generate_report.py > performance.md
+          cat performance.md
+
+      - name: Post performance comment
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const fs = require('fs');
+            const performance = fs.readFileSync('performance.md', 'utf8');
+            const body = `## ⚡ Performance Report\n\n${performance}`;
+
+            const { data: comments } = await github.rest.issues.listComments({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+            });
+
+            const botComment = comments.find(c =>
+              c.user.login === 'github-actions[bot]' && c.body.includes('## ⚡ Performance Report')
+            );
+
+            if (botComment) {
+              await github.rest.issues.updateComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                comment_id: botComment.id,
+                body: body,
+              });
+            } else {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: context.issue.number,
+                body: body,
+              });
+            }

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -87,6 +87,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "bench"
+version = "0.1.0"
+dependencies = [
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "bitflags"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,3 +1,6 @@
+[workspace]
+members = [".", "bench"]
+
 [package]
 name = "moca"
 version = "0.1.0"

--- a/bench/Cargo.toml
+++ b/bench/Cargo.toml
@@ -1,0 +1,8 @@
+[package]
+name = "bench"
+version = "0.1.0"
+edition = "2024"
+
+[dependencies]
+serde = { version = "1.0", features = ["derive"] }
+serde_json = "1.0"

--- a/bench/moca/fibonacci.mc
+++ b/bench/moca/fibonacci.mc
@@ -1,0 +1,9 @@
+// Benchmark: fibonacci(30) recursive
+fun fib(n: int) -> int {
+    if n <= 1 {
+        return n;
+    }
+    return fib(n - 1) + fib(n - 2);
+}
+
+print(fib(30));

--- a/bench/moca/mandelbrot.mc
+++ b/bench/moca/mandelbrot.mc
@@ -1,0 +1,53 @@
+// Benchmark: Mandelbrot set computation with max_iter=200
+// Simplified version for benchmarking (no output, just computation)
+fun mandelbrot_bench(max_iter: int) -> int {
+    let width = 80;
+    let height = 24;
+    var escape_count = 0;
+
+    let x_min = -2.0;
+    let x_max = 1.0;
+    let y_min = -1.0;
+    let y_max = 1.0;
+
+    let x_step = (x_max - x_min) / 80.0;
+    let y_step = (y_max - y_min) / 24.0;
+
+    var cy = y_min;
+    var py = 0;
+    while py < height {
+        var cx = x_min;
+        var px = 0;
+        while px < width {
+            var zr = 0.0;
+            var zi = 0.0;
+            var iter = 0;
+
+            while iter < max_iter {
+                let zr2 = zr * zr;
+                let zi2 = zi * zi;
+
+                if zr2 + zi2 > 4.0 {
+                    escape_count = escape_count + 1;
+                    iter = max_iter;
+                } else {
+                    let new_zr = zr2 - zi2 + cx;
+                    let new_zi = 2.0 * zr * zi + cy;
+                    zr = new_zr;
+                    zi = new_zi;
+                    iter = iter + 1;
+                }
+            }
+
+            cx = cx + x_step;
+            px = px + 1;
+        }
+
+        cy = cy + y_step;
+        py = py + 1;
+    }
+
+    return escape_count;
+}
+
+print(mandelbrot_bench(200));

--- a/bench/moca/nested_loop.mc
+++ b/bench/moca/nested_loop.mc
@@ -1,0 +1,16 @@
+// Benchmark: 500x500 nested loop
+fun nested_loop() {
+    var sum = 0;
+    var i = 0;
+    while i < 500 {
+        var j = 0;
+        while j < 500 {
+            sum = sum + i * j;
+            j = j + 1;
+        }
+        i = i + 1;
+    }
+    print(sum);
+}
+
+nested_loop();

--- a/bench/moca/sum_loop.mc
+++ b/bench/moca/sum_loop.mc
@@ -1,0 +1,12 @@
+// Benchmark: sum of 1 to 1,000,000
+fun sum_loop() {
+    var sum = 0;
+    var i = 1;
+    while i <= 1000000 {
+        sum = sum + i;
+        i = i + 1;
+    }
+    print(sum);
+}
+
+sum_loop();

--- a/bench/src/main.rs
+++ b/bench/src/main.rs
@@ -1,0 +1,176 @@
+use serde::Serialize;
+use std::env;
+use std::process::Command;
+use std::time::Instant;
+
+#[derive(Serialize)]
+struct BenchmarkResult {
+    name: String,
+    moca_time_secs: f64,
+    rust_time_secs: f64,
+}
+
+#[derive(Serialize)]
+struct BenchmarkOutput {
+    results: Vec<BenchmarkResult>,
+}
+
+// Rust reference implementations
+
+fn rust_sum_loop() {
+    let mut sum: i64 = 0;
+    for i in 1..=1_000_000 {
+        sum += i;
+    }
+    eprintln!("{}", sum);
+}
+
+fn rust_nested_loop() {
+    let mut sum: i64 = 0;
+    for i in 0..500 {
+        for j in 0..500 {
+            sum += i * j;
+        }
+    }
+    eprintln!("{}", sum);
+}
+
+fn rust_fibonacci(n: i32) -> i32 {
+    if n <= 1 {
+        n
+    } else {
+        rust_fibonacci(n - 1) + rust_fibonacci(n - 2)
+    }
+}
+
+fn rust_mandelbrot(max_iter: i32) -> i32 {
+    let width = 80;
+    let height = 24;
+    let mut escape_count = 0;
+
+    let x_min = -2.0_f64;
+    let x_max = 1.0_f64;
+    let y_min = -1.0_f64;
+    let y_max = 1.0_f64;
+
+    let x_step = (x_max - x_min) / 80.0;
+    let y_step = (y_max - y_min) / 24.0;
+
+    let mut cy = y_min;
+    for _ in 0..height {
+        let mut cx = x_min;
+        for _ in 0..width {
+            let mut zr = 0.0_f64;
+            let mut zi = 0.0_f64;
+            let mut iter = 0;
+
+            while iter < max_iter {
+                let zr2 = zr * zr;
+                let zi2 = zi * zi;
+
+                if zr2 + zi2 > 4.0 {
+                    escape_count += 1;
+                    break;
+                }
+
+                let new_zr = zr2 - zi2 + cx;
+                let new_zi = 2.0 * zr * zi + cy;
+                zr = new_zr;
+                zi = new_zi;
+                iter += 1;
+            }
+
+            cx += x_step;
+        }
+        cy += y_step;
+    }
+
+    escape_count
+}
+
+fn time_rust<F>(f: F) -> f64
+where
+    F: FnOnce(),
+{
+    let start = Instant::now();
+    f();
+    start.elapsed().as_secs_f64()
+}
+
+fn run_moca_benchmark(moca_path: &str, bench_file: &str) -> f64 {
+    let bench_path = format!(
+        "{}/bench/moca/{}.mc",
+        env!("CARGO_MANIFEST_DIR").trim_end_matches("/bench"),
+        bench_file
+    );
+
+    let start = Instant::now();
+    let output = Command::new(moca_path)
+        .arg("run")
+        .arg("--jit")
+        .arg("on")
+        .arg(&bench_path)
+        .output()
+        .expect("Failed to run moca");
+
+    let elapsed = start.elapsed().as_secs_f64();
+
+    if !output.status.success() {
+        eprintln!(
+            "Moca benchmark {} failed: {}",
+            bench_file,
+            String::from_utf8_lossy(&output.stderr)
+        );
+    }
+
+    elapsed
+}
+
+fn main() {
+    let args: Vec<String> = env::args().collect();
+    let moca_path = args
+        .get(1)
+        .map(|s| s.as_str())
+        .unwrap_or("./target/release/moca");
+
+    let mut results = Vec::new();
+
+    // sum_loop benchmark
+    let rust_time = time_rust(rust_sum_loop);
+    let moca_time = run_moca_benchmark(moca_path, "sum_loop");
+    results.push(BenchmarkResult {
+        name: "sum_loop".to_string(),
+        moca_time_secs: moca_time,
+        rust_time_secs: rust_time,
+    });
+
+    // nested_loop benchmark
+    let rust_time = time_rust(rust_nested_loop);
+    let moca_time = run_moca_benchmark(moca_path, "nested_loop");
+    results.push(BenchmarkResult {
+        name: "nested_loop".to_string(),
+        moca_time_secs: moca_time,
+        rust_time_secs: rust_time,
+    });
+
+    // fibonacci benchmark
+    let rust_time = time_rust(|| eprintln!("{}", rust_fibonacci(30)));
+    let moca_time = run_moca_benchmark(moca_path, "fibonacci");
+    results.push(BenchmarkResult {
+        name: "fibonacci".to_string(),
+        moca_time_secs: moca_time,
+        rust_time_secs: rust_time,
+    });
+
+    // mandelbrot benchmark
+    let rust_time = time_rust(|| eprintln!("{}", rust_mandelbrot(200)));
+    let moca_time = run_moca_benchmark(moca_path, "mandelbrot");
+    results.push(BenchmarkResult {
+        name: "mandelbrot".to_string(),
+        moca_time_secs: moca_time,
+        rust_time_secs: rust_time,
+    });
+
+    let output = BenchmarkOutput { results };
+    println!("{}", serde_json::to_string_pretty(&output).unwrap());
+}


### PR DESCRIPTION
## Summary

- Add benchmark infrastructure to track moca performance in PRs
- New `bench` crate with Rust reference implementations for comparison
- CI job posts performance comparison as PR comment

### Benchmarks included
| Name | Description |
|------|-------------|
| sum_loop | Sum of 1 to 1,000,000 |
| nested_loop | 500x500 nested loop |
| fibonacci | fib(30) recursive |
| mandelbrot | max_iter=200 |

### Output format
```
## ⚡ Performance Report

| Benchmark | Current | Rust | Main |
|-----------|---------|------|------|
| sum_loop | 0.456s | 0.012s (38x faster) | 0.480s 🟢 +5% |
```

## Test plan

- [x] `cargo run -p bench` works locally
- [ ] Verify PR comment is posted correctly

🤖 Generated with [Claude Code](https://claude.ai/code)