### PR TITLE
ci: add JIT off column to performance report

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -221,28 +221,29 @@ jobs:
           with open('main_bench.json') as f:
               main_data = json.load(f)
 
-          main_times = {r['name']: r['moca_time_secs'] for r in main_data['results']}
+          main_times = {r['name']: r['moca_jit_on_secs'] for r in main_data['results']}
 
           lines = []
-          lines.append("| Benchmark | Current | Rust | Main |")
-          lines.append("|-----------|---------|------|------|")
+          lines.append("| Benchmark | Current (JIT) | Current (no JIT) | Rust | Main |")
+          lines.append("|-----------|---------------|------------------|------|------|")
 
           for result in pr_data['results']:
               name = result['name']
-              current = result['moca_time_secs']
+              current_jit = result['moca_jit_on_secs']
+              current_no_jit = result['moca_jit_off_secs']
               rust = result['rust_time_secs']
-              main = main_times.get(name, current)
+              main = main_times.get(name, current_jit)
 
               # Calculate Rust comparison (how many times faster)
               if rust > 0:
-                  rust_ratio = current / rust
+                  rust_ratio = current_jit / rust
                   rust_str = f"{rust:.3f}s ({rust_ratio:.0f}x faster)"
               else:
                   rust_str = f"{rust:.3f}s"
 
               # Calculate main comparison (percentage change)
               if main > 0:
-                  pct_change = ((main - current) / main) * 100
+                  pct_change = ((main - current_jit) / main) * 100
                   if pct_change > 5:
                       icon = "🟢"
                       sign = "+"
@@ -256,7 +257,7 @@ jobs:
               else:
                   main_str = "N/A"
 
-              lines.append(f"| {name} | {current:.3f}s | {rust_str} | {main_str} |")
+              lines.append(f"| {name} | {current_jit:.3f}s | {current_no_jit:.3f}s | {rust_str} | {main_str} |")
 
           lines.append("")
           lines.append("Legend: 🟢 >5% faster, 🟡 ±5%, 🔴 >5% slower (vs main)")

--- a/bench/src/main.rs
+++ b/bench/src/main.rs
@@ -6,7 +6,8 @@ use std::time::Instant;
 #[derive(Serialize)]
 struct BenchmarkResult {
     name: String,
-    moca_time_secs: f64,
+    moca_jit_on_secs: f64,
+    moca_jit_off_secs: f64,
     rust_time_secs: f64,
 }
 
@@ -97,7 +98,7 @@ where
     start.elapsed().as_secs_f64()
 }
 
-fn run_moca_benchmark(moca_path: &str, bench_file: &str) -> f64 {
+fn run_moca_benchmark(moca_path: &str, bench_file: &str, jit: &str) -> f64 {
     let bench_path = format!(
         "{}/bench/moca/{}.mc",
         env!("CARGO_MANIFEST_DIR").trim_end_matches("/bench"),
@@ -108,7 +109,7 @@ fn run_moca_benchmark(moca_path: &str, bench_file: &str) -> f64 {
     let output = Command::new(moca_path)
         .arg("run")
         .arg("--jit")
-        .arg("on")
+        .arg(jit)
         .arg(&bench_path)
         .output()
         .expect("Failed to run moca");
@@ -117,8 +118,9 @@ fn run_moca_benchmark(moca_path: &str, bench_file: &str) -> f64 {
 
     if !output.status.success() {
         eprintln!(
-            "Moca benchmark {} failed: {}",
+            "Moca benchmark {} (jit={}) failed: {}",
             bench_file,
+            jit,
             String::from_utf8_lossy(&output.stderr)
         );
     }
@@ -137,37 +139,45 @@ fn main() {
 
     // sum_loop benchmark
     let rust_time = time_rust(rust_sum_loop);
-    let moca_time = run_moca_benchmark(moca_path, "sum_loop");
+    let moca_jit_on = run_moca_benchmark(moca_path, "sum_loop", "on");
+    let moca_jit_off = run_moca_benchmark(moca_path, "sum_loop", "off");
     results.push(BenchmarkResult {
         name: "sum_loop".to_string(),
-        moca_time_secs: moca_time,
+        moca_jit_on_secs: moca_jit_on,
+        moca_jit_off_secs: moca_jit_off,
         rust_time_secs: rust_time,
     });
 
     // nested_loop benchmark
     let rust_time = time_rust(rust_nested_loop);
-    let moca_time = run_moca_benchmark(moca_path, "nested_loop");
+    let moca_jit_on = run_moca_benchmark(moca_path, "nested_loop", "on");
+    let moca_jit_off = run_moca_benchmark(moca_path, "nested_loop", "off");
     results.push(BenchmarkResult {
         name: "nested_loop".to_string(),
-        moca_time_secs: moca_time,
+        moca_jit_on_secs: moca_jit_on,
+        moca_jit_off_secs: moca_jit_off,
         rust_time_secs: rust_time,
     });
 
     // fibonacci benchmark
     let rust_time = time_rust(|| eprintln!("{}", rust_fibonacci(30)));
-    let moca_time = run_moca_benchmark(moca_path, "fibonacci");
+    let moca_jit_on = run_moca_benchmark(moca_path, "fibonacci", "on");
+    let moca_jit_off = run_moca_benchmark(moca_path, "fibonacci", "off");
     results.push(BenchmarkResult {
         name: "fibonacci".to_string(),
-        moca_time_secs: moca_time,
+        moca_jit_on_secs: moca_jit_on,
+        moca_jit_off_secs: moca_jit_off,
         rust_time_secs: rust_time,
     });
 
     // mandelbrot benchmark
     let rust_time = time_rust(|| eprintln!("{}", rust_mandelbrot(200)));
-    let moca_time = run_moca_benchmark(moca_path, "mandelbrot");
+    let moca_jit_on = run_moca_benchmark(moca_path, "mandelbrot", "on");
+    let moca_jit_off = run_moca_benchmark(moca_path, "mandelbrot", "off");
     results.push(BenchmarkResult {
         name: "mandelbrot".to_string(),
-        moca_time_secs: moca_time,
+        moca_jit_on_secs: moca_jit_on,
+        moca_jit_off_secs: moca_jit_off,
         rust_time_secs: rust_time,
     });
 


### PR DESCRIPTION
## Summary

- Add `Current (no JIT)` column to performance report
- Shows both JIT on and JIT off execution times for comparison

### New output format
```
| Benchmark | Current (JIT) | Current (no JIT) | Rust | Main |
|-----------|---------------|------------------|------|------|
| sum_loop | 0.097s | 0.090s | 0.001s (143x faster) | 0.100s 🟢 +3% |
```

## Test plan

- [x] `cargo run -p bench` works locally with new JSON format
- [ ] Verify PR comment shows new column

🤖 Generated with [Claude Code](https://claude.ai/code)