### PR TITLE
fix: JIT int演算の負オフセットにldur/sturを使用

### DIFF
--- a/src/jit/aarch64.rs
+++ b/src/jit/aarch64.rs
@@ -298,6 +298,16 @@ impl<'a> AArch64Assembler<'a> {
         self.emit_raw(inst);
     }
 
+    /// STUR Xt, [Xn, #simm9] (store 64-bit, unscaled signed offset)
+    pub fn stur(&mut self, rt: Reg, rn: Reg, simm9: i16) {
+        // 1111 1000 000i iiii iiii 00nn nnnt tttt
+        let inst = 0xF8000000
+            | (((simm9 as u32) & 0x1FF) << 12)
+            | ((rn.code() as u32) << 5)
+            | (rt.code() as u32);
+        self.emit_raw(inst);
+    }
+
     /// STR Xt, [Xn, #imm12] (store 64-bit, unsigned offset)
     pub fn str(&mut self, rt: Reg, rn: Reg, imm12: u16) {
         // 1111 1001 00ii iiii iiii iinn nnnt tttt

--- a/src/jit/compiler.rs
+++ b/src/jit/compiler.rs
@@ -905,10 +905,10 @@ impl JitCompiler {
         // Load payloads only (tags known to be INT=0)
         asm.sub_imm(regs::VSTACK, regs::VSTACK, VALUE_SIZE);
         asm.ldr(regs::TMP1, regs::VSTACK, 8); // b
-        asm.ldr(regs::TMP0, regs::VSTACK, -8); // a (at VSTACK - VALUE_SIZE + 8)
+        asm.ldur(regs::TMP0, regs::VSTACK, -8); // a (at VSTACK - VALUE_SIZE + 8)
         asm.add(regs::TMP0, regs::TMP0, regs::TMP1);
         // a's tag slot is already TAG_INT (0), just write result payload
-        asm.str(regs::TMP0, regs::VSTACK, -8);
+        asm.stur(regs::TMP0, regs::VSTACK, -8);
 
         self.stack_depth = self.stack_depth.saturating_sub(1);
         Ok(())
@@ -919,9 +919,9 @@ impl JitCompiler {
         let mut asm = AArch64Assembler::new(&mut self.buf);
         asm.sub_imm(regs::VSTACK, regs::VSTACK, VALUE_SIZE);
         asm.ldr(regs::TMP1, regs::VSTACK, 8); // b
-        asm.ldr(regs::TMP0, regs::VSTACK, -8); // a
+        asm.ldur(regs::TMP0, regs::VSTACK, -8); // a
         asm.sub(regs::TMP0, regs::TMP0, regs::TMP1);
-        asm.str(regs::TMP0, regs::VSTACK, -8);
+        asm.stur(regs::TMP0, regs::VSTACK, -8);
 
         self.stack_depth = self.stack_depth.saturating_sub(1);
         Ok(())
@@ -932,9 +932,9 @@ impl JitCompiler {
         let mut asm = AArch64Assembler::new(&mut self.buf);
         asm.sub_imm(regs::VSTACK, regs::VSTACK, VALUE_SIZE);
         asm.ldr(regs::TMP1, regs::VSTACK, 8); // b
-        asm.ldr(regs::TMP0, regs::VSTACK, -8); // a
+        asm.ldur(regs::TMP0, regs::VSTACK, -8); // a
         asm.mul(regs::TMP0, regs::TMP0, regs::TMP1);
-        asm.str(regs::TMP0, regs::VSTACK, -8);
+        asm.stur(regs::TMP0, regs::VSTACK, -8);
 
         self.stack_depth = self.stack_depth.saturating_sub(1);
         Ok(())
@@ -945,9 +945,9 @@ impl JitCompiler {
         let mut asm = AArch64Assembler::new(&mut self.buf);
         asm.sub_imm(regs::VSTACK, regs::VSTACK, VALUE_SIZE);
         asm.ldr(regs::TMP1, regs::VSTACK, 8); // b (divisor)
-        asm.ldr(regs::TMP0, regs::VSTACK, -8); // a (dividend)
+        asm.ldur(regs::TMP0, regs::VSTACK, -8); // a (dividend)
         asm.sdiv(regs::TMP0, regs::TMP0, regs::TMP1);
-        asm.str(regs::TMP0, regs::VSTACK, -8);
+        asm.stur(regs::TMP0, regs::VSTACK, -8);
 
         self.stack_depth = self.stack_depth.saturating_sub(1);
         Ok(())


### PR DESCRIPTION
## Summary
- `ldr`/`str`は`u16`型の符号なしオフセットのみ対応しているが、int特化演算（add/sub/mul/div）で`-8`オフセットを渡しておりコンパイルエラーになっていた
- AArch64の`STUR`命令（符号付きオフセット対応のストア）を`AArch64Assembler`に追加
- `emit_add_int`/`emit_sub_int`/`emit_mul_int`/`emit_div_int`の負オフセット箇所を`ldur`/`stur`に置き換え

## Test plan
- [x] `cargo check` パス
- [x] `cargo test` 全289 + 17テストパス
- [x] `cargo clippy` パス

🤖 Generated with [Claude Code](https://claude.com/claude-code)