### PR TITLE
ci: just checkにstdのmoca lintチェックを追加

### DIFF
--- a/std/prelude.mc
+++ b/std/prelude.mc
@@ -889,7 +889,7 @@ impl<K, V> Map<K, V> {
 
     // Alias for put - used by index assignment desugar (map[key] = value)
     fun set(self, key: any, val: any) {
-        self[key] = val;
+        self.put(key, val);
     }
 
     // Generic get method - dispatches based on key type


### PR DESCRIPTION
## Summary
- `just check` に `moca-lint` タスクを追加し、`std/*.mc` に対して `moca lint` を実行するようにした
- `moca-lint` は `build` に依存し、ビルド済みバイナリで lint を実行する
- 警告が1つでもあればCIが失敗する

## 依存
- #87 (JITコンパイルエラー修正) を先にマージする必要あり。現状mainではビルドが通らないため

## Test plan
- [ ] #87 マージ後にCIが正常に動作することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)