### PR TITLE
refactor: remove dead mutable field from Statement::Let

### DIFF
--- a/src/compiler/ast.rs
+++ b/src/compiler/ast.rs
@@ -99,7 +99,6 @@ pub struct Block {
 pub enum Statement {
     Let {
         name: String,
-        mutable: bool,
         type_annotation: Option<TypeAnnotation>,
         init: Expr,
         span: Span,

--- a/src/compiler/desugar.rs
+++ b/src/compiler/desugar.rs
@@ -148,14 +148,12 @@ impl Desugar {
         match stmt {
             Statement::Let {
                 name,
-                mutable,
                 type_annotation,
                 init,
                 span,
                 inferred_type,
             } => Statement::Let {
                 name,
-                mutable,
                 type_annotation,
                 init: self.desugar_expr(init),
                 span,
@@ -603,7 +601,6 @@ impl Desugar {
 
         statements.push(Statement::Let {
             name: var_name.clone(),
-            mutable: false,
             type_annotation: Some(type_annotation),
             init: init_expr,
             span,
@@ -699,7 +696,6 @@ impl Desugar {
 
         statements.push(Statement::Let {
             name: var_name.clone(),
-            mutable: false,
             type_annotation: Some(type_annotation),
             init: init_expr,
             span,

--- a/src/compiler/dump.rs
+++ b/src/compiler/dump.rs
@@ -139,17 +139,15 @@ impl<'a> AstPrinter<'a> {
         match stmt {
             Statement::Let {
                 name,
-                mutable,
                 type_annotation,
                 init,
                 ..
             } => {
-                let mut_str = if *mutable { "mut " } else { "" };
                 let type_str = type_annotation
                     .as_ref()
                     .map(|t| format!(": {}", t))
                     .unwrap_or_default();
-                self.write_prefixed(prefix, &format!("Let: {}{}{}", mut_str, name, type_str));
+                self.write_prefixed(prefix, &format!("Let: {}{}", name, type_str));
                 self.newline();
                 self.write_indent_with(parent_prefix);
                 self.print_expr(init, "└── ", true, parent_prefix);

--- a/src/compiler/monomorphise.rs
+++ b/src/compiler/monomorphise.rs
@@ -749,14 +749,12 @@ fn substitute_statement(stmt: &Statement, type_map: &HashMap<String, Type>) -> S
     match stmt {
         Statement::Let {
             name,
-            mutable,
             type_annotation,
             init,
             span,
             inferred_type,
         } => Statement::Let {
             name: name.clone(),
-            mutable: *mutable,
             type_annotation: type_annotation
                 .as_ref()
                 .map(|ta| substitute_type_annotation(ta, type_map)),
@@ -1209,14 +1207,12 @@ fn rewrite_statement(stmt: &Statement, instantiations: &HashSet<Instantiation>) 
     match stmt {
         Statement::Let {
             name,
-            mutable,
             type_annotation,
             init,
             span,
             inferred_type,
         } => Statement::Let {
             name: name.clone(),
-            mutable: *mutable,
             type_annotation: type_annotation.clone(),
             init: rewrite_expr(init, instantiations),
             span: *span,

--- a/src/compiler/parser.rs
+++ b/src/compiler/parser.rs
@@ -358,7 +358,6 @@ impl<'a> Parser<'a> {
 
         Ok(Statement::Let {
             name,
-            mutable: false,
             type_annotation,
             init,
             span,
@@ -1634,9 +1633,8 @@ mod tests {
         let program = parse("let x = 42;").unwrap();
         assert_eq!(program.items.len(), 1);
         match &program.items[0] {
-            Item::Statement(Statement::Let { name, mutable, .. }) => {
+            Item::Statement(Statement::Let { name, .. }) => {
                 assert_eq!(name, "x");
-                assert!(!mutable);
             }
             _ => panic!("expected let statement"),
         }


### PR DESCRIPTION
## Summary
- `Statement::Let` の `mutable: bool` フィールドを削除
- PR #94 で `let` が常に再代入可能になったため、このフィールドは常に `false` がセットされるだけの dead code だった
- ast.rs, parser.rs, desugar.rs, monomorphise.rs, dump.rs の5ファイルから関連コードを除去

## Test plan
- [x] 全665テストがパスすることを確認
- [x] `cargo clippy` がクリーンであることを確認

🤖 Generated with [Claude Code](https://claude.ai/code)
via [Happy](https://happy.engineering)