### PR TITLE
refactor: desugar ForRange to While loop in desugar phase

### DIFF
--- a/src/compiler/codegen.rs
+++ b/src/compiler/codegen.rs
@@ -665,65 +665,6 @@ impl Codegen {
                 self.compile_expr(expr, ops)?;
                 ops.push(Op::Drop); // Discard result
             }
-            ResolvedStatement::ForRange {
-                slot,
-                start,
-                end,
-                inclusive,
-                body,
-            } => {
-                // For-range loop: for i in start..end { body }
-                // Desugars to:
-                //   let __end = end;        (slot + 1)
-                //   let i = start;          (slot)
-                //   while i < __end {       (or <= for inclusive)
-                //     body
-                //     i = i + 1;
-                //   }
-
-                let var_slot = *slot + self.local_offset;
-                let end_slot = slot + 1 + self.local_offset;
-
-                // Store end value
-                self.compile_expr(end, ops)?;
-                ops.push(Op::LocalSet(end_slot));
-
-                // Initialize loop var to start
-                self.compile_expr(start, ops)?;
-                ops.push(Op::LocalSet(var_slot));
-
-                let loop_start = ops.len();
-
-                // Check: i < end (or i <= end for inclusive)
-                ops.push(Op::LocalGet(var_slot));
-                ops.push(Op::LocalGet(end_slot));
-                if *inclusive {
-                    ops.push(Op::I64LeS);
-                } else {
-                    ops.push(Op::I64LtS);
-                }
-
-                let jump_to_end = ops.len();
-                ops.push(Op::BrIfFalse(0)); // Placeholder
-
-                // Body
-                for stmt in body {
-                    self.compile_statement(stmt, ops)?;
-                }
-
-                // i = i + 1
-                ops.push(Op::LocalGet(var_slot));
-                ops.push(Op::I64Const(1));
-                ops.push(Op::I64Add);
-                ops.push(Op::LocalSet(var_slot));
-
-                // Jump back to loop start
-                ops.push(Op::Jmp(loop_start));
-
-                // End of loop
-                let loop_end = ops.len();
-                ops[jump_to_end] = Op::BrIfFalse(loop_end);
-            }
             ResolvedStatement::RefCellStore { slot, value } => {
                 // Store to a promoted var variable through its RefCell (outer scope)
                 // LocalGet(slot) gives the RefCell ref, then store value into RefCell[0]

--- a/src/compiler/dump.rs
+++ b/src/compiler/dump.rs
@@ -1016,28 +1016,6 @@ impl ResolvedProgramPrinter {
                 self.print_block(catch_block, &catch_child);
             }
 
-            ResolvedStatement::ForRange {
-                slot,
-                start,
-                end,
-                inclusive,
-                body,
-            } => {
-                let op = if *inclusive { "..=" } else { ".." };
-                self.write(&format!("{}ForRange slot:{} {}", prefix, slot, op));
-                self.newline();
-                let start_child = format!("{}│   ", parent_prefix);
-                self.write_indent_with(parent_prefix);
-                self.print_expr(start, "├── start: ", &start_child);
-                self.write_indent_with(parent_prefix);
-                self.print_expr(end, "├── end: ", &start_child);
-                self.write_indent_with(parent_prefix);
-                self.write("└── body:");
-                self.newline();
-                let body_child = format!("{}    ", parent_prefix);
-                self.print_block(body, &body_child);
-            }
-
             ResolvedStatement::Expr { expr } => {
                 self.write(&format!("{}Expr", prefix));
                 self.newline();

--- a/src/compiler/monomorphise.rs
+++ b/src/compiler/monomorphise.rs
@@ -215,12 +215,8 @@ impl InstantiationCollector {
                 self.collect_expr(iterable);
                 self.collect_block(body);
             }
-            Statement::ForRange {
-                start, end, body, ..
-            } => {
-                self.collect_expr(start);
-                self.collect_expr(end);
-                self.collect_block(body);
+            Statement::ForRange { .. } => {
+                unreachable!("ForRange should be desugared before monomorphisation")
             }
             Statement::Return { value, .. } => {
                 if let Some(value) = value {
@@ -829,21 +825,9 @@ fn substitute_statement(stmt: &Statement, type_map: &HashMap<String, Type>) -> S
             body: substitute_block(body, type_map),
             span: *span,
         },
-        Statement::ForRange {
-            var,
-            start,
-            end,
-            inclusive,
-            body,
-            span,
-        } => Statement::ForRange {
-            var: var.clone(),
-            start: substitute_expr(start, type_map),
-            end: substitute_expr(end, type_map),
-            inclusive: *inclusive,
-            body: substitute_block(body, type_map),
-            span: *span,
-        },
+        Statement::ForRange { .. } => {
+            unreachable!("ForRange should be desugared before monomorphisation")
+        }
         Statement::Return { value, span } => Statement::Return {
             value: value.as_ref().map(|v| substitute_expr(v, type_map)),
             span: *span,
@@ -1302,21 +1286,9 @@ fn rewrite_statement(stmt: &Statement, instantiations: &HashSet<Instantiation>) 
             body: rewrite_block(body, instantiations),
             span: *span,
         },
-        Statement::ForRange {
-            var,
-            start,
-            end,
-            inclusive,
-            body,
-            span,
-        } => Statement::ForRange {
-            var: var.clone(),
-            start: rewrite_expr(start, instantiations),
-            end: rewrite_expr(end, instantiations),
-            inclusive: *inclusive,
-            body: rewrite_block(body, instantiations),
-            span: *span,
-        },
+        Statement::ForRange { .. } => {
+            unreachable!("ForRange should be desugared before monomorphisation")
+        }
         Statement::Return { value, span } => Statement::Return {
             value: value.as_ref().map(|v| rewrite_expr(v, instantiations)),
             span: *span,


### PR DESCRIPTION
## Summary
- ForRange (`for i in 0..10 { ... }`) を desugar フェーズで `let + while` ループに展開するよう変更
- `ResolvedStatement::ForRange` バリアントを削除し、resolver/codegen/monomorphise/dump から ForRange 固有の処理を除去
- desugar 前のパス（parser, typechecker, linter, LSP）は `Statement::ForRange` をそのまま保持

## 変更内容
- **desugar.rs**: ForRange → `let __for_end_N = end; let i = start; while i < __for_end_N { body; i = i + 1; }` に展開
- **codegen.rs**: ForRange の codegen を削除 (-59行)
- **resolver.rs**: `ResolvedStatement::ForRange` と関連処理を削除
- **monomorphise.rs**: ForRange 3箇所を unreachable に変更
- **dump.rs**: resolved レベルの ForRange 表示を削除

## Test plan
- [x] 全17テストパス（for_range.mc のスナップショットテスト含む）
- [x] `cargo fmt && cargo check && cargo test && cargo clippy` all clean

🤖 Generated with [Claude Code](https://claude.ai/code)