### PR TITLE
perf: increase quicksort and text_counting benchmark workloads

### DIFF
--- a/tests/snapshot_tests.rs
+++ b/tests/snapshot_tests.rs
@@ -894,7 +894,7 @@ fn rust_text_counting<W: Write>(writer: &mut W) {
     ];
     let mut counts = [0i64; 26];
 
-    for _ in 0..1000 {
+    for _ in 0..10000 {
         for &ch in text.iter() {
             let idx = rust_to_letter_index(ch);
             if idx >= 0 {
@@ -922,8 +922,8 @@ fn rust_text_counting<W: Write>(writer: &mut W) {
 fn rust_quicksort<W: Write>(writer: &mut W) {
     // Same LCG as moca _perf_lcg_next
     let mut seed: i64 = 42;
-    let mut v: Vec<i64> = Vec::with_capacity(1000);
-    for _ in 0..1000 {
+    let mut v: Vec<i64> = Vec::with_capacity(10000);
+    for _ in 0..10000 {
         seed = (seed * 1103515245 + 12345) % 2147483648;
         if seed < 0 {
             seed = -seed;

--- a/tests/snapshots/performance/quicksort.mc
+++ b/tests/snapshots/performance/quicksort.mc
@@ -1,4 +1,4 @@
-// Benchmark: quicksort 1000 random integers
+// Benchmark: quicksort 10000 random integers
 // Uses LCG for deterministic random number generation.
 
 // JIT-compilable: pure integer arithmetic LCG
@@ -12,11 +12,11 @@ fun _perf_lcg_next(seed: int) -> int {
 }
 
 fun quicksort_benchmark() {
-    // Generate 1000 random integers using LCG
+    // Generate 10000 random integers using LCG
     let v: Vec<int> = Vec<int> { ptr: 0, len: 0, cap: 0 };
     let seed = 42;
     let i = 0;
-    while i < 1000 {
+    while i < 10000 {
         seed = _perf_lcg_next(seed);
         v.push(seed % 10000);
         i = i + 1;
@@ -27,7 +27,7 @@ fun quicksort_benchmark() {
 
     // Print all sorted elements
     i = 0;
-    while i < 1000 {
+    while i < 10000 {
         print(v[i]);
         i = i + 1;
     }

--- a/tests/snapshots/performance/text_counting.mc
+++ b/tests/snapshots/performance/text_counting.mc
@@ -32,7 +32,7 @@ fun count_chars() {
 
     // Count letters across 1000 iterations (case-insensitive, skip non-letters)
     let iter = 0;
-    while iter < 1000 {
+    while iter < 10000 {
         let i = 0;
         while i < len(text) {
             let ch = text[i];


### PR DESCRIPTION
## Summary

- **quicksort**: 1000 → 10000 elements (was 0.007s, too light)
- **text_counting**: 1000 → 10000 iterations (was 0.024s, too light)

Both benchmarks had very light workloads compared to other benchmarks (0.06s–0.26s range), making them less useful for tracking performance regressions.

## Test plan

- [x] `cargo test snapshot_performance` — output matches Rust reference
- [x] All tests pass
- [x] `cargo clippy` clean

🤖 Generated with [Claude Code](https://claude.ai/code)