### PR TITLE
feat: add MicroOp-based loop JIT compiler for AArch64 (Phase 2)

### DIFF
--- a/src/jit/compiler.rs
+++ b/src/jit/compiler.rs
@@ -98,6 +98,9 @@ pub struct CompiledLoop {
     pub loop_end_pc: usize,
     /// Stack map for GC (pc_offset -> bitmap of stack slots with refs)
     pub stack_map: HashMap<usize, Vec<bool>>,
+    /// Total number of VRegs (locals + temps) for MicroOp JIT.
+    /// 0 means legacy Op-based JIT.
+    pub total_regs: usize,
 }
 
 #[cfg(target_arch = "aarch64")]
@@ -404,6 +407,7 @@ impl JitCompiler {
             loop_start_pc,
             loop_end_pc,
             stack_map: self.stack_map,
+            total_regs: 0,
         })
     }
 

--- a/src/jit/compiler_x86_64.rs
+++ b/src/jit/compiler_x86_64.rs
@@ -88,6 +88,9 @@ pub struct CompiledLoop {
     pub loop_end_pc: usize,
     /// Stack map for GC (pc_offset -> bitmap of stack slots with refs)
     pub stack_map: HashMap<usize, Vec<bool>>,
+    /// Total number of VRegs (locals + temps) for MicroOp JIT.
+    /// 0 means legacy Op-based JIT.
+    pub total_regs: usize,
 }
 
 impl CompiledLoop {
@@ -390,6 +393,7 @@ impl JitCompiler {
             loop_start_pc,
             loop_end_pc,
             stack_map: self.stack_map,
+            total_regs: 0,
         })
     }
 


### PR DESCRIPTION
## Summary
- Add `compile_loop()` method to `MicroOpJitCompiler` in `compiler_microop.rs` for loop-level JIT compilation using MicroOp IR
- Add `total_regs` field to `CompiledLoop` struct for MicroOp/legacy JIT dispatch
- Update `jit_compile_loop` (AArch64) to convert Op→MicroOp via `pc_map` and compile with `MicroOpJitCompiler`
- Update `execute_jit_loop` (AArch64) to marshal `total_regs` VRegs and swap calling convention for MicroOp JIT

## Details

Phase 2 of the MicroOp JIT migration (issue #107). Loops with integer arithmetic, comparisons, branches, and function calls can now be JIT compiled via MicroOp IR on AArch64. Loops containing unsupported instructions (heap ops, string ops, etc.) gracefully fall back to interpreter execution.

Key design decisions:
- Loop range specified in MicroOp PC space (`pc_map[old_target]..pc_map[old_pc]`)
- `CompiledLoop.loop_start_pc/loop_end_pc` remain in Op PC space for `execute_jit_loop` return value compatibility
- `total_regs > 0` discriminates MicroOp JIT from legacy Op JIT (same pattern as `CompiledCode`)
- Peephole optimization: `try_fuse_cmp_branch_loop` redirects loop exit targets to epilogue label

## Test plan
- [x] `cargo fmt` — clean
- [x] `cargo check` — compiles
- [x] `cargo test` — all 339 tests pass
- [x] `cargo clippy` — no warnings

🤖 Generated with [Claude Code](https://claude.ai/code)