### PR TITLE
feat: add JIT support for string operations

### DIFF
--- a/src/compiler/dump.rs
+++ b/src/compiler/dump.rs
@@ -2135,6 +2135,44 @@ fn format_single_microop(output: &mut String, mop: &MicroOp, chunk: &Chunk) {
             format_vreg(src)
         )),
 
+        // String operations
+        MicroOp::StringConst { dst, idx } => {
+            let s = chunk
+                .strings
+                .get(*idx)
+                .map(|s| {
+                    let escaped = s.replace('\n', "\\n").replace('\t', "\\t");
+                    if escaped.len() > 40 {
+                        format!("{}...", &escaped[..40])
+                    } else {
+                        escaped
+                    }
+                })
+                .unwrap_or_else(|| "<?>".to_string());
+            output.push_str(&format!(
+                "StringConst {}, {} ; \"{}\"",
+                format_vreg(dst),
+                idx,
+                s
+            ))
+        }
+        MicroOp::ToString { dst, src } => output.push_str(&format!(
+            "ToString {}, {}",
+            format_vreg(dst),
+            format_vreg(src)
+        )),
+        MicroOp::PrintDebug { dst, src } => output.push_str(&format!(
+            "PrintDebug {}, {}",
+            format_vreg(dst),
+            format_vreg(src)
+        )),
+        MicroOp::StringConcat { dst, a, b } => output.push_str(&format!(
+            "StringConcat {}, {}, {}",
+            format_vreg(dst),
+            format_vreg(a),
+            format_vreg(b)
+        )),
+
         // Stack bridge
         MicroOp::StackPush { src } => output.push_str(&format!("StackPush {}", format_vreg(src))),
         MicroOp::StackPop { dst } => output.push_str(&format!("StackPop {}", format_vreg(dst))),

--- a/src/jit/marshal.rs
+++ b/src/jit/marshal.rs
@@ -193,6 +193,12 @@ pub struct JitCallContext {
     pub string_cache: *const u64,
     /// Number of entries in the string cache
     pub string_cache_len: u64,
+    /// ToString helper: (ctx, tag, payload) -> JitReturn (returns Ref to string)
+    pub to_string_helper: unsafe extern "C" fn(*mut JitCallContext, u64, u64) -> JitReturn,
+    /// PrintDebug helper: (ctx, tag, payload) -> JitReturn (returns same value)
+    pub print_debug_helper: unsafe extern "C" fn(*mut JitCallContext, u64, u64) -> JitReturn,
+    /// String concat helper: (ctx, ref_a, ref_b) -> JitReturn (returns Ref to new string)
+    pub string_concat_helper: unsafe extern "C" fn(*mut JitCallContext, u64, u64) -> JitReturn,
 }
 
 /// Type signature for call helper function.

--- a/src/vm/microop.rs
+++ b/src/vm/microop.rs
@@ -392,6 +392,35 @@ pub enum MicroOp {
     },
 
     // ========================================
+    // String operations
+    // ========================================
+    /// Load string constant from cache (or allocate via helper).
+    /// dst = string_cache[idx] (Ref to heap string)
+    StringConst {
+        dst: VReg,
+        idx: usize,
+    },
+    /// Convert value to string representation.
+    /// dst = to_string(src) (Ref to newly allocated heap string)
+    ToString {
+        dst: VReg,
+        src: VReg,
+    },
+    /// Print value to output and return original value.
+    /// dst = src (after printing src to output)
+    PrintDebug {
+        dst: VReg,
+        src: VReg,
+    },
+    /// Concatenate two strings.
+    /// dst = concat(a, b) (Ref to newly allocated heap string)
+    StringConcat {
+        dst: VReg,
+        a: VReg,
+        b: VReg,
+    },
+
+    // ========================================
     // Stack Bridge (for Raw op interop)
     // ========================================
     /// Push vreg value onto the operand stack (for Raw ops to consume).


### PR DESCRIPTION
## Summary

- Add native MicroOp variants (`StringConst`, `ToString`, `PrintDebug`, `StringConcat`) so string operations are no longer handled as `Raw` MicroOps
- Add `Vse::RegRef` to the MicroOp converter to statically track Ref types and emit `StringConcat` at conversion time (instead of runtime tag checks)
- Extend `JitCallContext` with 3 new helper function pointers (`to_string_helper`, `print_debug_helper`, `string_concat_helper`)
- Implement x86_64 and AArch64 JIT codegen for all 4 string ops, including fast-path string constant caching

## Performance

`string_interpolation` benchmark: **2272x → 240x** vs Rust (~9.5x speedup)

Previously the hot loop couldn't be JIT compiled because it contained `StringConst`/`ToString`/`PrintDebug` which were `Raw` MicroOps. Now the entire loop is JIT compiled with native helper calls.

## Test plan

- [x] `cargo fmt` - clean
- [x] `cargo check` - clean
- [x] `cargo test` - 322 unit + 17 integration tests pass
- [x] `cargo clippy` - clean (no warnings)
- [x] `cargo test snapshot_performance -- --nocapture` - benchmark improvement confirmed

Closes #115

🤖 Generated with [Claude Code](https://claude.ai/code)
via [Happy](https://happy.engineering)