### PR TITLE
perf(jit): add JIT support for HeapAllocDynSimple/HeapAllocString

### DIFF
--- a/src/compiler/dump.rs
+++ b/src/compiler/dump.rs
@@ -2136,6 +2136,19 @@ fn format_single_microop(output: &mut String, mop: &MicroOp, chunk: &Chunk) {
             format_vreg(src)
         )),
 
+        // Heap allocation operations
+        MicroOp::HeapAllocDynSimple { dst, size } => output.push_str(&format!(
+            "HeapAllocDynSimple {}, {}",
+            format_vreg(dst),
+            format_vreg(size)
+        )),
+        MicroOp::HeapAllocString { dst, data_ref, len } => output.push_str(&format!(
+            "HeapAllocString {}, {}, {}",
+            format_vreg(dst),
+            format_vreg(data_ref),
+            format_vreg(len)
+        )),
+
         // String operations
         MicroOp::StringConst { dst, idx } => {
             let s = chunk

--- a/src/jit/marshal.rs
+++ b/src/jit/marshal.rs
@@ -197,6 +197,10 @@ pub struct JitCallContext {
     pub to_string_helper: unsafe extern "C" fn(*mut JitCallContext, u64, u64) -> JitReturn,
     /// PrintDebug helper: (ctx, tag, payload) -> JitReturn (returns same value)
     pub print_debug_helper: unsafe extern "C" fn(*mut JitCallContext, u64, u64) -> JitReturn,
+    /// HeapAllocDynSimple helper: (ctx, size) -> JitReturn (returns Ref)
+    pub heap_alloc_dyn_simple_helper: unsafe extern "C" fn(*mut JitCallContext, u64) -> JitReturn,
+    /// HeapAllocString helper: (ctx, data_ref_payload, len_payload) -> JitReturn (returns Ref)
+    pub heap_alloc_string_helper: unsafe extern "C" fn(*mut JitCallContext, u64, u64) -> JitReturn,
 }
 
 /// Type signature for call helper function.

--- a/src/vm/microop.rs
+++ b/src/vm/microop.rs
@@ -392,6 +392,23 @@ pub enum MicroOp {
     },
 
     // ========================================
+    // Heap allocation operations
+    // ========================================
+    /// Allocate a heap object with `size` null-initialized slots.
+    /// dst = Ref to newly allocated object.
+    HeapAllocDynSimple {
+        dst: VReg,
+        size: VReg,
+    },
+    /// Allocate a string object: [data_ref, len] with ObjectKind::String.
+    /// dst = Ref to newly allocated string struct.
+    HeapAllocString {
+        dst: VReg,
+        data_ref: VReg,
+        len: VReg,
+    },
+
+    // ========================================
     // String operations
     // ========================================
     /// Load string constant from cache (or allocate via helper).

--- a/src/vm/microop_converter.rs
+++ b/src/vm/microop_converter.rs
@@ -855,6 +855,23 @@ pub fn convert(func: &Function) -> ConvertedFunction {
             }
 
             // ============================================================
+            // Heap allocation operations
+            // ============================================================
+            Op::HeapAllocDynSimple => {
+                let size = pop_vreg(&mut vstack, &mut micro_ops, &mut next_temp, &mut max_temp);
+                let dst = alloc_temp(&mut next_temp, &mut max_temp);
+                micro_ops.push(MicroOp::HeapAllocDynSimple { dst, size });
+                vstack.push(Vse::RegRef(dst));
+            }
+            Op::HeapAllocString => {
+                let len = pop_vreg(&mut vstack, &mut micro_ops, &mut next_temp, &mut max_temp);
+                let data_ref = pop_vreg(&mut vstack, &mut micro_ops, &mut next_temp, &mut max_temp);
+                let dst = alloc_temp(&mut next_temp, &mut max_temp);
+                micro_ops.push(MicroOp::HeapAllocString { dst, data_ref, len });
+                vstack.push(Vse::RegRef(dst));
+            }
+
+            // ============================================================
             // Raw fallback (everything else)
             // ============================================================
             _ => {


### PR DESCRIPTION
## Summary

- `HeapAllocDynSimple` と `HeapAllocString` を正式な MicroOp に昇格し、JIT helper 関数呼び出しとして実装
- #118 で `string_concat` を std 関数に移行した結果、外側ループが JIT コンパイルに失敗していたレグレッションを修正
- AArch64 / x86_64 両方の JIT エミッション対応

### Before
```
[JIT/MicroOp] Failed to compile loop in 'string_interp_bench' Op PC 4..379:
  Unsupported MicroOp for JIT: Discriminant(66)
```
`string_interpolation`: **509.9x** vs Rust

### After
```
[JIT/MicroOp] Compiled loop in 'string_interp_bench' Op PC 4..379 (12288 bytes)
```
`string_interpolation`: **48.8x** vs Rust (**10.4x improvement**)

## Test plan
- [x] `cargo fmt && cargo check && cargo test && cargo clippy` all pass
- [x] `--trace-jit` confirms outer loop JIT compilation success
- [x] `snapshot_performance` benchmark passes with expected improvement

🤖 Generated with [Claude Code](https://claude.ai/code)