### PR TITLE
refactor: unify HeapAllocString into HeapAllocArray with kind parameter

### DIFF
--- a/src/compiler/codegen.rs
+++ b/src/compiler/codegen.rs
@@ -728,7 +728,7 @@ impl Codegen {
 
                 // 2. Create Array<T> struct: { ptr: data_ptr, len: n }
                 ops.push(Op::I64Const(n as i64));
-                ops.push(Op::HeapAllocArray(2)); // Array struct with [ptr, len]
+                ops.push(Op::HeapAllocArray(2, 2)); // Array struct with [ptr, len]
             }
             ResolvedExpr::Index {
                 object,
@@ -1100,7 +1100,7 @@ impl Codegen {
                         }
                         self.compile_expr(&args[0], ops)?;
                         self.compile_expr(&args[1], ops)?;
-                        ops.push(Op::HeapAllocString);
+                        ops.push(Op::HeapAllocArray(2, 1)); // String struct with [ptr, len]
                     }
                     // CLI argument builtins
                     "argc" => {
@@ -1479,7 +1479,7 @@ impl Codegen {
             }
             "HeapAllocArray" => {
                 let n = self.expect_int_arg(args, 0, op_name)? as usize;
-                Ok(Op::HeapAllocArray(n))
+                Ok(Op::HeapAllocArray(n, 2))
             }
             "HeapAllocDyn" | "AllocHeapDyn" => Ok(Op::HeapAllocDyn),
             "HeapAllocDynSimple" => Ok(Op::HeapAllocDynSimple),

--- a/src/compiler/dump.rs
+++ b/src/compiler/dump.rs
@@ -1687,10 +1687,18 @@ impl<'a> Disassembler<'a> {
 
             // Heap operations
             Op::HeapAlloc(n) => self.output.push_str(&format!("HeapAlloc {}", n)),
-            Op::HeapAllocArray(n) => self.output.push_str(&format!("HeapAllocArray {}", n)),
+            Op::HeapAllocArray(n, kind) => {
+                let kind_str = match kind {
+                    0 => "Slots",
+                    1 => "String",
+                    2 => "Array",
+                    _ => "Unknown",
+                };
+                self.output
+                    .push_str(&format!("HeapAllocArray {} ({})", n, kind_str));
+            }
             Op::HeapAllocDyn => self.output.push_str("HeapAllocDyn"),
             Op::HeapAllocDynSimple => self.output.push_str("HeapAllocDynSimple"),
-            Op::HeapAllocString => self.output.push_str("HeapAllocString"),
             Op::HeapLoad(offset) => self.output.push_str(&format!("HeapLoad {}", offset)),
             Op::HeapStore(offset) => self.output.push_str(&format!("HeapStore {}", offset)),
             Op::HeapLoadDyn => self.output.push_str("HeapLoadDyn"),
@@ -2142,12 +2150,26 @@ fn format_single_microop(output: &mut String, mop: &MicroOp, chunk: &Chunk) {
             format_vreg(dst),
             format_vreg(size)
         )),
-        MicroOp::HeapAllocString { dst, data_ref, len } => output.push_str(&format!(
-            "HeapAllocString {}, {}, {}",
-            format_vreg(dst),
-            format_vreg(data_ref),
-            format_vreg(len)
-        )),
+        MicroOp::HeapAllocTyped {
+            dst,
+            data_ref,
+            len,
+            kind,
+        } => {
+            let kind_str = match kind {
+                0 => "Slots",
+                1 => "String",
+                2 => "Array",
+                _ => "Unknown",
+            };
+            output.push_str(&format!(
+                "HeapAllocTyped {}, {}, {} ({})",
+                format_vreg(dst),
+                format_vreg(data_ref),
+                format_vreg(len),
+                kind_str
+            ));
+        }
         MicroOp::StringConst { dst, idx } => {
             let s = chunk
                 .strings

--- a/src/jit/compiler_microop.rs
+++ b/src/jit/compiler_microop.rs
@@ -391,9 +391,12 @@ impl MicroOpJitCompiler {
             MicroOp::PrintDebug { dst, src } => self.emit_print_debug(dst, src),
             // Heap allocation operations
             MicroOp::HeapAllocDynSimple { dst, size } => self.emit_heap_alloc_dyn_simple(dst, size),
-            MicroOp::HeapAllocString { dst, data_ref, len } => {
-                self.emit_heap_alloc_string(dst, data_ref, len)
-            }
+            MicroOp::HeapAllocTyped {
+                dst,
+                data_ref,
+                len,
+                kind,
+            } => self.emit_heap_alloc_typed(dst, data_ref, len, *kind),
             // Stack bridge (spill/restore across calls)
             MicroOp::StackPush { src } => self.emit_stack_push(src),
             MicroOp::StackPop { dst } => self.emit_stack_pop(dst),
@@ -1620,18 +1623,19 @@ impl MicroOpJitCompiler {
         Ok(())
     }
 
-    /// Emit HeapAllocString: call helper(ctx, data_ref_payload, len_payload) -> (tag, payload)
-    fn emit_heap_alloc_string(
+    /// Emit HeapAllocTyped: call helper(ctx, data_ref_payload, len_payload, kind) -> (tag, payload)
+    fn emit_heap_alloc_typed(
         &mut self,
         dst: &VReg,
         data_ref: &VReg,
         len: &VReg,
+        kind: u8,
     ) -> Result<(), String> {
         {
             let mut asm = AArch64Assembler::new(&mut self.buf);
             // Save callee-saved
             asm.stp_pre(regs::VM_CTX, regs::FRAME_BASE, -16);
-            // Args: X0=ctx, X1=data_ref_payload, X2=len_payload
+            // Args: X0=ctx, X1=data_ref_payload, X2=len_payload, X3=kind
             asm.mov(Reg::X0, regs::VM_CTX);
             asm.ldr(
                 Reg::X1,
@@ -1639,7 +1643,8 @@ impl MicroOpJitCompiler {
                 Self::vreg_payload_offset(data_ref),
             );
             asm.ldr(Reg::X2, regs::FRAME_BASE, Self::vreg_payload_offset(len));
-            // Load heap_alloc_string_helper from JitCallContext offset 96
+            asm.movz(Reg::X3, kind as u16, 0);
+            // Load heap_alloc_typed_helper from JitCallContext offset 96
             asm.ldr(regs::TMP4, regs::VM_CTX, 96);
             asm.blr(regs::TMP4);
             // Restore callee-saved

--- a/src/jit/marshal.rs
+++ b/src/jit/marshal.rs
@@ -199,8 +199,9 @@ pub struct JitCallContext {
     pub print_debug_helper: unsafe extern "C" fn(*mut JitCallContext, u64, u64) -> JitReturn,
     /// HeapAllocDynSimple helper: (ctx, size) -> JitReturn (returns Ref)
     pub heap_alloc_dyn_simple_helper: unsafe extern "C" fn(*mut JitCallContext, u64) -> JitReturn,
-    /// HeapAllocString helper: (ctx, data_ref_payload, len_payload) -> JitReturn (returns Ref)
-    pub heap_alloc_string_helper: unsafe extern "C" fn(*mut JitCallContext, u64, u64) -> JitReturn,
+    /// HeapAllocTyped helper: (ctx, data_ref_payload, len_payload, kind) -> JitReturn (returns Ref)
+    pub heap_alloc_typed_helper:
+        unsafe extern "C" fn(*mut JitCallContext, u64, u64, u64) -> JitReturn,
 }
 
 /// Type signature for call helper function.

--- a/src/vm/microop.rs
+++ b/src/vm/microop.rs
@@ -400,12 +400,13 @@ pub enum MicroOp {
         dst: VReg,
         size: VReg,
     },
-    /// Allocate a string object: [data_ref, len] with ObjectKind::String.
-    /// dst = Ref to newly allocated string struct.
-    HeapAllocString {
+    /// Allocate a typed 2-slot object: [data_ref, len] with specified ObjectKind.
+    /// kind: 0=Slots, 1=String, 2=Array.
+    HeapAllocTyped {
         dst: VReg,
         data_ref: VReg,
         len: VReg,
+        kind: u8,
     },
 
     // ========================================

--- a/src/vm/microop_converter.rs
+++ b/src/vm/microop_converter.rs
@@ -863,11 +863,17 @@ pub fn convert(func: &Function) -> ConvertedFunction {
                 micro_ops.push(MicroOp::HeapAllocDynSimple { dst, size });
                 vstack.push(Vse::RegRef(dst));
             }
-            Op::HeapAllocString => {
+            Op::HeapAllocArray(2, kind) if *kind == 1 || *kind == 2 => {
+                // Typed 2-slot alloc (String or Array with ptr+len layout)
                 let len = pop_vreg(&mut vstack, &mut micro_ops, &mut next_temp, &mut max_temp);
                 let data_ref = pop_vreg(&mut vstack, &mut micro_ops, &mut next_temp, &mut max_temp);
                 let dst = alloc_temp(&mut next_temp, &mut max_temp);
-                micro_ops.push(MicroOp::HeapAllocString { dst, data_ref, len });
+                micro_ops.push(MicroOp::HeapAllocTyped {
+                    dst,
+                    data_ref,
+                    len,
+                    kind: *kind,
+                });
                 vstack.push(Vse::RegRef(dst));
             }
 

--- a/src/vm/ops.rs
+++ b/src/vm/ops.rs
@@ -147,12 +147,11 @@ pub enum Op {
     // Heap Operations
     // ========================================
     HeapAlloc(usize),
-    /// Like HeapAlloc but marks the object with ObjectKind::Array for display.
-    HeapAllocArray(usize),
+    /// Like HeapAlloc but marks the object with a specific ObjectKind.
+    /// Second parameter is the kind: 0=Slots, 1=String, 2=Array.
+    HeapAllocArray(usize, u8),
     HeapAllocDyn,
     HeapAllocDynSimple,
-    /// Allocate a string object: pop len, pop data_ref → push [data_ref, len] with ObjectKind::String
-    HeapAllocString,
     HeapLoad(usize),
     HeapStore(usize),
     HeapLoadDyn,
@@ -288,10 +287,9 @@ impl Op {
             Op::Call(_, _) => "Call",
             Op::Ret => "Ret",
             Op::HeapAlloc(_) => "HeapAlloc",
-            Op::HeapAllocArray(_) => "HeapAllocArray",
+            Op::HeapAllocArray(_, _) => "HeapAllocArray",
             Op::HeapAllocDyn => "HeapAllocDyn",
             Op::HeapAllocDynSimple => "HeapAllocDynSimple",
-            Op::HeapAllocString => "HeapAllocString",
             Op::HeapLoad(_) => "HeapLoad",
             Op::HeapStore(_) => "HeapStore",
             Op::HeapLoadDyn => "HeapLoadDyn",

--- a/src/vm/stackmap.rs
+++ b/src/vm/stackmap.rs
@@ -173,7 +173,7 @@ pub fn is_safepoint(op: &super::ops::Op, pc: usize) -> bool {
         Op::Call(_, _) => true,
 
         // Heap allocation is also a safepoint
-        Op::HeapAlloc(_) | Op::HeapAllocArray(_) => true,
+        Op::HeapAlloc(_) | Op::HeapAllocArray(_, _) => true,
 
         // Backward jumps are safepoints
         Op::Jmp(target) => *target < pc,

--- a/src/vm/verifier.rs
+++ b/src/vm/verifier.rs
@@ -442,17 +442,16 @@ impl Verifier {
             Op::Ret => (1, 0),               // pops return value
 
             // Heap operations
-            Op::HeapAlloc(n) => (*n, 1),      // pops n slots, pushes ref
-            Op::HeapAllocArray(n) => (*n, 1), // pops n slots, pushes ref (Array kind)
-            Op::HeapAllocDyn => (1, 1),       // pops size + size values, pushes ref (simplified)
+            Op::HeapAlloc(n) => (*n, 1), // pops n slots, pushes ref
+            Op::HeapAllocArray(n, _) => (*n, 1), // pops n slots, pushes ref
+            Op::HeapAllocDyn => (1, 1),  // pops size + size values, pushes ref (simplified)
             Op::HeapAllocDynSimple => (1, 1), // pops size, pushes ref (null-initialized)
-            Op::HeapAllocString => (2, 1),    // pops data_ref and len, pushes string ref
-            Op::HeapLoad(_) => (1, 1),        // pops ref, pushes value
-            Op::HeapStore(_) => (2, 0),       // pops ref and value
-            Op::HeapLoadDyn => (2, 1),        // pops ref and index, pushes value
-            Op::HeapStoreDyn => (3, 0),       // pops ref, index, and value
-            Op::HeapLoad2 => (2, 1), // pops ref and index, pushes value (indirect via slot 0)
-            Op::HeapStore2 => (3, 0), // pops ref, index, and value (indirect via slot 0)
+            Op::HeapLoad(_) => (1, 1),   // pops ref, pushes value
+            Op::HeapStore(_) => (2, 0),  // pops ref and value
+            Op::HeapLoadDyn => (2, 1),   // pops ref and index, pushes value
+            Op::HeapStoreDyn => (3, 0),  // pops ref, index, and value
+            Op::HeapLoad2 => (2, 1),     // pops ref and index, pushes value (indirect via slot 0)
+            Op::HeapStore2 => (3, 0),    // pops ref, index, and value (indirect via slot 0)
             // System / Builtins
             Op::Syscall(_, argc) => (*argc, 1), // pops argc args, pushes result
             Op::GcHint(_) => (0, 0),


### PR DESCRIPTION
## Summary

- `Op::HeapAllocString` を削除し、`Op::HeapAllocArray(usize, u8)` に統合
- 第2引数で ObjectKind を指定 (0=Slots, 1=String, 2=Array)
- 文字列と配列の割り当てパスを統一（内部表現は同じ `[data_ref, len]`）
- 12ファイルを横断的に更新（ops, vm, microop, bytecode, codegen, JIT, etc.）

Closes #120

## Test plan

- [x] `cargo fmt` / `cargo check` / `cargo test` / `cargo clippy` all pass
- [x] All 17 snapshot tests pass (basic, stdlib, performance, etc.)
- [x] String operations (concat, interpolation, to_string) work correctly
- [x] Array operations still work correctly

🤖 Generated with [Claude Code](https://claude.ai/code)