### PR TITLE
perf: JIT direct call for already-compiled functions

### DIFF
--- a/src/vm/vm.rs
+++ b/src/vm/vm.rs
@@ -371,12 +371,26 @@ impl VM {
             return; // Already compiled
         }
 
+        // Build map of already-compiled functions for direct call generation.
+        let compiled_fns: HashMap<usize, (u64, usize)> = self
+            .jit_functions
+            .iter()
+            .map(|(&idx, compiled)| {
+                let entry: unsafe extern "C" fn(
+                    *mut u8,
+                    *mut JitValue,
+                    *mut JitValue,
+                ) -> JitReturn = unsafe { compiled.entry_point() };
+                (idx, (entry as usize as u64, compiled.total_regs))
+            })
+            .collect();
+
         // Convert to MicroOp IR first
         use super::microop_converter;
         let converted = microop_converter::convert(func);
 
         let compiler = MicroOpJitCompiler::new();
-        match compiler.compile(&converted, func.locals_count, func_index) {
+        match compiler.compile(&converted, func.locals_count, func_index, compiled_fns) {
             Ok(compiled) => {
                 if self.trace_jit {
                     eprintln!(
@@ -410,12 +424,26 @@ impl VM {
             return; // Already compiled
         }
 
+        // Build map of already-compiled functions for direct call generation.
+        let compiled_fns: HashMap<usize, (u64, usize)> = self
+            .jit_functions
+            .iter()
+            .map(|(&idx, compiled)| {
+                let entry: unsafe extern "C" fn(
+                    *mut u8,
+                    *mut JitValue,
+                    *mut JitValue,
+                ) -> JitReturn = unsafe { compiled.entry_point() };
+                (idx, (entry as usize as u64, compiled.total_regs))
+            })
+            .collect();
+
         // Convert to MicroOp IR first
         use super::microop_converter;
         let converted = microop_converter::convert(func);
 
         let compiler = MicroOpJitCompiler::new();
-        match compiler.compile(&converted, func.locals_count, func_index) {
+        match compiler.compile(&converted, func.locals_count, func_index, compiled_fns) {
             Ok(compiled) => {
                 if self.trace_jit {
                     eprintln!(


### PR DESCRIPTION
## Summary

- JIT-compiled関数が既にコンパイル済みの関数を呼び出す場合、call_helper VMトランポリンを経由せずに、calleeのエントリポイントアドレスをコンパイル時immediateとして埋め込み直接callする
- x86-64とAArch64の両アーキテクチャに対応
- 安全性のため、recompilationは行わない（stale pointer問題を回避）。最初のコンパイル時に既にコンパイル済みの関数のみが直接呼び出しの対象

## Benchmark

| Benchmark | Before | After | Improvement |
|---|---|---|---|
| sum_loop | 0.0299s | 0.0311s | ~same |
| nested_loop | 0.0279s | 0.0290s | ~same |
| mandelbrot | 0.0313s | 0.0312s | ~same |
| fibonacci | 0.1369s | 0.1408s | ~same |
| **mutual_recursion** | **0.3292s** | **0.1719s** | **1.9x faster** |
| text_counting | 0.0500s | 0.0516s | ~same |
| quicksort | 0.0169s | 0.0169s | ~same |
| string_interpolation | 0.0148s | 0.0149s | ~same |

## Test plan

- [x] `cargo fmt` — pass
- [x] `cargo check` — pass
- [x] `cargo test` — 全322ユニットテスト + 17統合テスト pass
- [x] `cargo clippy` — pass
- [x] `cargo test --release snapshot_performance` — 全ベンチマーク pass

🤖 Generated with [Claude Code](https://claude.ai/code)