### PR TITLE
perf: eliminate intermediate string allocation for float interpolation

### DIFF
--- a/src/compiler/codegen.rs
+++ b/src/compiler/codegen.rs
@@ -157,7 +157,9 @@ impl Codegen {
             ResolvedExpr::AssociatedFunctionCall { .. } => ValueType::Ref,
             ResolvedExpr::SpawnFunc { .. } => ValueType::I64,
             ResolvedExpr::Builtin { name, .. } => match name.as_str() {
-                "len" | "argc" | "parse_int" => ValueType::I64,
+                "len" | "argc" | "parse_int" | "_float_digit_count" | "_float_write_to" => {
+                    ValueType::I64
+                }
                 "type_of" | "__float_to_string" | "channel" | "recv" | "argv" | "args"
                 | "__alloc_heap" | "__alloc_string" => ValueType::Ref,
                 "__heap_load" => ValueType::I64, // Returns raw slot value; type unknown at compile time
@@ -1013,6 +1015,25 @@ impl Codegen {
                         }
                         self.compile_expr(&args[0], ops)?;
                         ops.push(Op::FloatToString);
+                    }
+                    "_float_digit_count" => {
+                        if args.len() != 1 {
+                            return Err("_float_digit_count takes exactly 1 argument".to_string());
+                        }
+                        self.compile_expr(&args[0], ops)?;
+                        ops.push(Op::FloatDigitCount);
+                    }
+                    "_float_write_to" => {
+                        if args.len() != 3 {
+                            return Err(
+                                "_float_write_to takes exactly 3 arguments (buf, offset, float)"
+                                    .to_string(),
+                            );
+                        }
+                        self.compile_expr(&args[0], ops)?;
+                        self.compile_expr(&args[1], ops)?;
+                        self.compile_expr(&args[2], ops)?;
+                        ops.push(Op::FloatWriteTo);
                     }
                     "parse_int" => {
                         if args.len() != 1 {

--- a/src/compiler/dump.rs
+++ b/src/compiler/dump.rs
@@ -1711,6 +1711,8 @@ impl<'a> Disassembler<'a> {
             Op::PrintDebug => self.output.push_str("PrintDebug"),
             Op::TypeOf => self.output.push_str("TypeOf"),
             Op::FloatToString => self.output.push_str("ToString"),
+            Op::FloatDigitCount => self.output.push_str("FloatDigitCount"),
+            Op::FloatWriteTo => self.output.push_str("FloatWriteTo"),
             Op::ParseInt => self.output.push_str("ParseInt"),
             // Exception handling
             Op::Throw => self.output.push_str("Throw"),
@@ -2193,6 +2195,23 @@ fn format_single_microop(output: &mut String, mop: &MicroOp, chunk: &Chunk) {
         MicroOp::FloatToString { dst, src } => output.push_str(&format!(
             "ToString {}, {}",
             format_vreg(dst),
+            format_vreg(src)
+        )),
+        MicroOp::FloatDigitCount { dst, src } => output.push_str(&format!(
+            "FloatDigitCount {}, {}",
+            format_vreg(dst),
+            format_vreg(src)
+        )),
+        MicroOp::FloatWriteTo {
+            dst,
+            buf,
+            offset,
+            src,
+        } => output.push_str(&format!(
+            "FloatWriteTo {}, {}, {}, {}",
+            format_vreg(dst),
+            format_vreg(buf),
+            format_vreg(offset),
             format_vreg(src)
         )),
         MicroOp::PrintDebug { dst, src } => output.push_str(&format!(

--- a/src/compiler/resolver.rs
+++ b/src/compiler/resolver.rs
@@ -294,6 +294,8 @@ impl<'a> Resolver<'a> {
                 "len".to_string(),
                 "type_of".to_string(),
                 "__float_to_string".to_string(),
+                "_float_digit_count".to_string(),
+                "_float_write_to".to_string(),
                 "parse_int".to_string(),
                 // Thread operations
                 "spawn".to_string(),

--- a/src/compiler/typechecker.rs
+++ b/src/compiler/typechecker.rs
@@ -2566,6 +2566,30 @@ impl TypeChecker {
                 }
                 Some(Type::String)
             }
+            "_float_digit_count" => {
+                if args.len() != 1 {
+                    self.errors.push(TypeError::new(
+                        "_float_digit_count expects 1 argument",
+                        span,
+                    ));
+                }
+                for arg in args {
+                    self.infer_expr(arg, env);
+                }
+                Some(Type::Int)
+            }
+            "_float_write_to" => {
+                if args.len() != 3 {
+                    self.errors.push(TypeError::new(
+                        "_float_write_to expects 3 arguments (buf, offset, float)",
+                        span,
+                    ));
+                }
+                for arg in args {
+                    self.infer_expr(arg, env);
+                }
+                Some(Type::Int)
+            }
             "parse_int" => {
                 if args.len() != 1 {
                     self.errors

--- a/src/jit/compiler_microop.rs
+++ b/src/jit/compiler_microop.rs
@@ -386,6 +386,8 @@ impl MicroOpJitCompiler {
                 | MicroOp::HeapLoad2 { dst, .. }
                 | MicroOp::StackPop { dst }
                 | MicroOp::FloatToString { dst, .. }
+                | MicroOp::FloatDigitCount { dst, .. }
+                | MicroOp::FloatWriteTo { dst, .. }
                 | MicroOp::PrintDebug { dst, .. }
                 | MicroOp::HeapAllocDynSimple { dst, .. }
                 | MicroOp::HeapAllocTyped { dst, .. }
@@ -549,6 +551,13 @@ impl MicroOpJitCompiler {
             // String operations
             MicroOp::StringConst { dst, idx } => self.emit_string_const(dst, *idx),
             MicroOp::FloatToString { dst, src } => self.emit_float_to_string(dst, src),
+            MicroOp::FloatDigitCount { dst, src } => self.emit_float_digit_count(dst, src),
+            MicroOp::FloatWriteTo {
+                dst,
+                buf,
+                offset,
+                src,
+            } => self.emit_float_write_to(dst, buf, offset, src),
             MicroOp::PrintDebug { dst, src } => self.emit_print_debug(dst, src),
             // Heap allocation operations
             MicroOp::HeapAllocDynSimple { dst, size } => self.emit_heap_alloc_dyn_simple(dst, size),
@@ -926,7 +935,7 @@ impl MicroOpJitCompiler {
     }
 
     /// JitCallContext offset for jit_function_table pointer.
-    const JIT_FUNC_TABLE_OFFSET: u16 = 104;
+    const JIT_FUNC_TABLE_OFFSET: u16 = 120;
 
     /// Emit a function call that looks up the callee in the JIT function table at runtime.
     /// If the callee is compiled (entry != 0), calls it directly. Otherwise falls back to
@@ -1825,6 +1834,54 @@ impl MicroOpJitCompiler {
             asm.ldr(Reg::X1, regs::FRAME_BASE, src_shadow_off);
             asm.ldr(Reg::X2, regs::FRAME_BASE, Self::vreg_offset(src));
             asm.ldr(regs::TMP4, regs::VM_CTX, 72);
+            asm.blr(regs::TMP4);
+            asm.ldp_post(regs::VM_CTX, regs::FRAME_BASE, 16);
+            // Store payload to frame, tag to shadow
+            asm.str(Reg::X1, regs::FRAME_BASE, Self::vreg_offset(dst));
+            asm.str(Reg::X0, regs::FRAME_BASE, dst_shadow_off);
+        }
+        Ok(())
+    }
+
+    /// Emit FloatDigitCount: call float_digit_count_helper(ctx, float_payload) -> (tag, payload)
+    fn emit_float_digit_count(&mut self, dst: &VReg, src: &VReg) -> Result<(), String> {
+        let dst_shadow_off = self.shadow_tag_offset(dst);
+        {
+            let mut asm = AArch64Assembler::new(&mut self.buf);
+            asm.stp_pre(regs::VM_CTX, regs::FRAME_BASE, -16);
+            asm.mov(Reg::X0, regs::VM_CTX);
+            // X1 = float payload (raw bits)
+            asm.ldr(Reg::X1, regs::FRAME_BASE, Self::vreg_offset(src));
+            asm.ldr(regs::TMP4, regs::VM_CTX, 104);
+            asm.blr(regs::TMP4);
+            asm.ldp_post(regs::VM_CTX, regs::FRAME_BASE, 16);
+            // Store payload to frame, tag to shadow
+            asm.str(Reg::X1, regs::FRAME_BASE, Self::vreg_offset(dst));
+            asm.str(Reg::X0, regs::FRAME_BASE, dst_shadow_off);
+        }
+        Ok(())
+    }
+
+    /// Emit FloatWriteTo: call float_write_to_helper(ctx, buf_payload, offset, float_payload) -> (tag, payload)
+    fn emit_float_write_to(
+        &mut self,
+        dst: &VReg,
+        buf: &VReg,
+        offset: &VReg,
+        src: &VReg,
+    ) -> Result<(), String> {
+        let dst_shadow_off = self.shadow_tag_offset(dst);
+        {
+            let mut asm = AArch64Assembler::new(&mut self.buf);
+            asm.stp_pre(regs::VM_CTX, regs::FRAME_BASE, -16);
+            asm.mov(Reg::X0, regs::VM_CTX);
+            // X1 = buf ref payload (index)
+            asm.ldr(Reg::X1, regs::FRAME_BASE, Self::vreg_offset(buf));
+            // X2 = offset
+            asm.ldr(Reg::X2, regs::FRAME_BASE, Self::vreg_offset(offset));
+            // X3 = float payload (raw bits)
+            asm.ldr(Reg::X3, regs::FRAME_BASE, Self::vreg_offset(src));
+            asm.ldr(regs::TMP4, regs::VM_CTX, 112);
             asm.blr(regs::TMP4);
             asm.ldp_post(regs::VM_CTX, regs::FRAME_BASE, 16);
             // Store payload to frame, tag to shadow

--- a/src/jit/marshal.rs
+++ b/src/jit/marshal.rs
@@ -202,6 +202,11 @@ pub struct JitCallContext {
     /// HeapAllocTyped helper: (ctx, data_ref_payload, len_payload, kind) -> JitReturn (returns Ref)
     pub heap_alloc_typed_helper:
         unsafe extern "C" fn(*mut JitCallContext, u64, u64, u64) -> JitReturn,
+    /// FloatDigitCount helper: (ctx, float_payload) -> JitReturn (returns i64 length)
+    pub float_digit_count_helper: unsafe extern "C" fn(*mut JitCallContext, u64) -> JitReturn,
+    /// FloatWriteTo helper: (ctx, buf_ref_payload, offset, float_payload) -> JitReturn (returns i64 new offset)
+    pub float_write_to_helper:
+        unsafe extern "C" fn(*mut JitCallContext, u64, u64, u64) -> JitReturn,
     /// Pointer to JIT function table for direct call dispatch.
     /// Layout: [entry_0, total_regs_0, entry_1, total_regs_1, ...] (u64 pairs).
     /// entry == 0 means the function is not yet JIT-compiled.

--- a/src/vm/bytecode.rs
+++ b/src/vm/bytecode.rs
@@ -402,7 +402,8 @@ const OP_HEAP_LOAD2: u8 = 105;
 const OP_CALL_INDIRECT: u8 = 106;
 
 const OP_HEAP_STORE2: u8 = 107;
-// 108 was OP_HEAP_ALLOC_STRING, now unused (merged into HeapAllocArray with kind)
+const OP_FLOAT_DIGIT_COUNT: u8 = 108;
+const OP_FLOAT_WRITE_TO: u8 = 109;
 
 fn write_op<W: Write>(w: &mut W, op: &Op) -> io::Result<()> {
     match op {
@@ -586,6 +587,8 @@ fn write_op<W: Write>(w: &mut W, op: &Op) -> io::Result<()> {
         Op::PrintDebug => w.write_all(&[OP_PRINT_DEBUG])?,
         Op::TypeOf => w.write_all(&[OP_TYPE_OF])?,
         Op::FloatToString => w.write_all(&[OP_FLOAT_TO_STRING])?,
+        Op::FloatDigitCount => w.write_all(&[OP_FLOAT_DIGIT_COUNT])?,
+        Op::FloatWriteTo => w.write_all(&[OP_FLOAT_WRITE_TO])?,
         Op::ParseInt => w.write_all(&[OP_PARSE_INT])?,
         // Exception Handling
         Op::Throw => w.write_all(&[OP_THROW])?,
@@ -753,6 +756,8 @@ fn read_op<R: Read>(r: &mut R) -> Result<Op, BytecodeError> {
         OP_PRINT_DEBUG => Op::PrintDebug,
         OP_TYPE_OF => Op::TypeOf,
         OP_FLOAT_TO_STRING => Op::FloatToString,
+        OP_FLOAT_DIGIT_COUNT => Op::FloatDigitCount,
+        OP_FLOAT_WRITE_TO => Op::FloatWriteTo,
         OP_PARSE_INT => Op::ParseInt,
         // Exception Handling
         OP_THROW => Op::Throw,
@@ -1180,6 +1185,8 @@ mod tests {
             Op::PrintDebug,
             Op::TypeOf,
             Op::FloatToString,
+            Op::FloatDigitCount,
+            Op::FloatWriteTo,
             Op::ParseInt,
             // Exception Handling
             Op::Throw,

--- a/src/vm/microop.rs
+++ b/src/vm/microop.rs
@@ -425,6 +425,20 @@ pub enum MicroOp {
         dst: VReg,
         src: VReg,
     },
+    /// Returns length of float's string representation.
+    /// dst = float_digit_count(src) (i64 length)
+    FloatDigitCount {
+        dst: VReg,
+        src: VReg,
+    },
+    /// Write float's string representation directly into heap buffer.
+    /// dst = float_write_to(buf, offset, src) → new offset (i64)
+    FloatWriteTo {
+        dst: VReg,
+        buf: VReg,
+        offset: VReg,
+        src: VReg,
+    },
     /// Print value to output and return original value.
     /// dst = src (after printing src to output)
     PrintDebug {

--- a/src/vm/microop_converter.rs
+++ b/src/vm/microop_converter.rs
@@ -1432,6 +1432,59 @@ pub fn convert(func: &Function) -> ConvertedFunction {
                 micro_ops.push(MicroOp::FloatToString { dst, src });
                 vstack.push(Vse::RegRef(dst));
             }
+            Op::FloatDigitCount => {
+                let src = pop_vreg(
+                    &mut vstack,
+                    &mut micro_ops,
+                    &mut next_temp,
+                    &mut max_temp,
+                    &mut vreg_types,
+                );
+                let dst = alloc_temp(
+                    &mut next_temp,
+                    &mut max_temp,
+                    &mut vreg_types,
+                    ValueType::I64,
+                );
+                micro_ops.push(MicroOp::FloatDigitCount { dst, src });
+                vstack.push(Vse::Reg(dst));
+            }
+            Op::FloatWriteTo => {
+                let src = pop_vreg(
+                    &mut vstack,
+                    &mut micro_ops,
+                    &mut next_temp,
+                    &mut max_temp,
+                    &mut vreg_types,
+                );
+                let offset = pop_vreg(
+                    &mut vstack,
+                    &mut micro_ops,
+                    &mut next_temp,
+                    &mut max_temp,
+                    &mut vreg_types,
+                );
+                let buf = pop_vreg(
+                    &mut vstack,
+                    &mut micro_ops,
+                    &mut next_temp,
+                    &mut max_temp,
+                    &mut vreg_types,
+                );
+                let dst = alloc_temp(
+                    &mut next_temp,
+                    &mut max_temp,
+                    &mut vreg_types,
+                    ValueType::I64,
+                );
+                micro_ops.push(MicroOp::FloatWriteTo {
+                    dst,
+                    buf,
+                    offset,
+                    src,
+                });
+                vstack.push(Vse::Reg(dst));
+            }
             Op::PrintDebug => {
                 let src = pop_vreg(
                     &mut vstack,

--- a/src/vm/ops.rs
+++ b/src/vm/ops.rs
@@ -169,6 +169,8 @@ pub enum Op {
     PrintDebug,
     TypeOf,
     FloatToString,
+    FloatDigitCount,
+    FloatWriteTo,
     ParseInt,
 
     // ========================================
@@ -301,6 +303,8 @@ impl Op {
             Op::PrintDebug => "PrintDebug",
             Op::TypeOf => "TypeOf",
             Op::FloatToString => "FloatToString",
+            Op::FloatDigitCount => "FloatDigitCount",
+            Op::FloatWriteTo => "FloatWriteTo",
             Op::ParseInt => "ParseInt",
             Op::Throw => "Throw",
             Op::TryBegin(_) => "TryBegin",

--- a/src/vm/verifier.rs
+++ b/src/vm/verifier.rs
@@ -458,6 +458,8 @@ impl Verifier {
             Op::PrintDebug => (1, 1),    // pops value, pushes return value
             Op::TypeOf => (1, 1),        // pops value, pushes type string
             Op::FloatToString => (1, 1), // pops value, pushes string
+            Op::FloatDigitCount => (1, 1), // pops float, pushes int (length)
+            Op::FloatWriteTo => (3, 1),  // pops buf+offset+float, pushes int (new offset)
             Op::ParseInt => (1, 1),      // pops string, pushes int
             // Exception handling
             Op::Throw => (1, 0),


### PR DESCRIPTION
## Summary

- Add `_float_digit_count` / `_float_write_to` Rust-backed builtins for direct buffer writes
- Modify desugar to treat floats like ints in string interpolation (no intermediate heap string)
- Add JIT support for both AArch64 and x86-64 backends
- Expand `JitCallContext` with two new helper function pointers (offsets 104, 112)

### Before
```
$"value={f}"
  → __float_to_string(f)      // allocate heap string
  → _str_copy_to(buf, off, s) // copy into final buffer
```

### After
```
$"value={f}"
  → _float_digit_count(f)          // compute length (no allocation)
  → _float_write_to(buf, off, f)   // write directly into buffer
```

### Files changed (14)

| Layer | Files | Change |
|-------|-------|--------|
| VM core | `ops.rs`, `microop.rs`, `vm.rs` | +2 opcodes, interpreter handlers, JIT helpers |
| Pipeline | `microop_converter.rs`, `bytecode.rs`, `verifier.rs` | Conversion, serialization, stack effects |
| Compiler | `resolver.rs`, `typechecker.rs`, `codegen.rs`, `dump.rs` | Register builtins, type inference, codegen |
| Desugar | `desugar.rs` | `PartInfo::Float` variant with direct-write pattern |
| JIT | `marshal.rs`, `compiler_microop.rs`, `compiler_microop_x86_64.rs` | JitCallContext expansion, emission for both backends |

Closes #131

## Test plan

- [x] `cargo fmt` — clean
- [x] `cargo check` — clean
- [x] `cargo test` — 325 + 17 tests pass
- [x] `cargo clippy` — clean
- [x] Existing `string_interpolation.mc` snapshot covers float interpolation (`$"bool={b}, float={f}"`)

🤖 Generated with [Claude Code](https://claude.ai/code)