### PR TITLE
feat: compile-time to_string specialization by argument type

### DIFF
--- a/std/prelude.mc
+++ b/std/prelude.mc
@@ -626,6 +626,20 @@ fun _int_to_string(n: int) -> string {
     return __alloc_string(data, dcount);
 }
 
+// Internal: convert float to string (single heap allocation).
+fun _float_to_string(f: float) -> string {
+    let dcount = _float_digit_count(f);
+    let data = __alloc_heap(dcount);
+    _float_write_to(data, 0, f);
+    return __alloc_string(data, dcount);
+}
+
+// Internal: convert bool to string.
+fun _bool_to_string(b: bool) -> string {
+    if b { return "true"; }
+    return "false";
+}
+
 // Convert any value to its string representation.
 fun to_string(x: any) -> string {
     let t = type_of(x);
@@ -636,16 +650,10 @@ fun to_string(x: any) -> string {
         return _int_to_string(x);
     }
     if t == "float" {
-        let dcount = _float_digit_count(x);
-        let data = __alloc_heap(dcount);
-        _float_write_to(data, 0, x);
-        return __alloc_string(data, dcount);
+        return _float_to_string(x);
     }
     if t == "bool" {
-        if x {
-            return "true";
-        }
-        return "false";
+        return _bool_to_string(x);
     }
     return "nil";
 }


### PR DESCRIPTION
## Summary
- `to_string(x)` 呼び出しを desugar フェーズでコンパイル時の引数型に基づいて型別関数に書き換え
  - `string` → 引数をそのまま返す（identity）
  - `int` → `_int_to_string(x)`
  - `float` → `_float_to_string(x)`
  - `bool` → `_bool_to_string(x)`
  - 未知 → 従来の `to_string(x)` にフォールバック
- String interpolation (1-2 parts) でも同じ特殊化を適用
- `_float_to_string` と `_bool_to_string` ヘルパーを `std/prelude.mc` に追加

## Motivation
Issue #144 (any 削減ロードマップ) の Phase 2。`to_string(x: any)` のランタイム `type_of()` ディスパッチを排除。

## Test plan
- [x] `cargo fmt` / `cargo check` / `cargo test` / `cargo clippy` 全てパス
- [x] to_string テスト、string interpolation テスト、mandelbrot テスト全て通過

🤖 Generated with [Claude Code](https://claude.ai/code)