### PR TITLE
feat: compile-time string equality specialization via desugar

### DIFF
--- a/src/compiler/desugar.rs
+++ b/src/compiler/desugar.rs
@@ -9,7 +9,7 @@
 
 use crate::compiler::ast::{
     AsmBlock, BinaryOp, Block, Expr, FnDef, ImplBlock, Item, NewLiteralElement, Param, Program,
-    Statement, StructDef, StructField,
+    Statement, StructDef, StructField, UnaryOp,
 };
 use crate::compiler::lexer::Span;
 use crate::compiler::types::{Type, TypeAnnotation};
@@ -561,20 +561,49 @@ impl Desugar {
                 inferred_type,
             },
 
-            // Binary - desugar both sides
+            // Binary - desugar both sides, specialize string equality
             Expr::Binary {
                 op,
                 left,
                 right,
                 span,
                 inferred_type,
-            } => Expr::Binary {
-                op,
-                left: Box::new(self.desugar_expr(*left)),
-                right: Box::new(self.desugar_expr(*right)),
-                span,
-                inferred_type,
-            },
+            } => {
+                let left_type = left.inferred_type().cloned();
+                let left = Box::new(self.desugar_expr(*left));
+                let right = Box::new(self.desugar_expr(*right));
+
+                // String equality: a == b → _string_eq(a, b), a != b → !_string_eq(a, b)
+                if matches!(left_type.as_ref(), Some(Type::String))
+                    && matches!(op, BinaryOp::Eq | BinaryOp::Ne)
+                {
+                    let call = Expr::Call {
+                        callee: "_string_eq".to_string(),
+                        type_args: vec![],
+                        args: vec![*left, *right],
+                        span,
+                        inferred_type: Some(Type::Bool),
+                    };
+                    if op == BinaryOp::Ne {
+                        Expr::Unary {
+                            op: UnaryOp::Not,
+                            operand: Box::new(call),
+                            span,
+                            inferred_type: Some(Type::Bool),
+                        }
+                    } else {
+                        call
+                    }
+                } else {
+                    Expr::Binary {
+                        op,
+                        left,
+                        right,
+                        span,
+                        inferred_type,
+                    }
+                }
+            }
 
             // Call - desugar arguments, specialize to_string by argument type
             Expr::Call {

--- a/std/prelude.mc
+++ b/std/prelude.mc
@@ -742,6 +742,26 @@ fun time_format(epoch_secs: int) -> string {
 // String Operations
 // ============================================================================
 
+// Compare two strings by content (length + data array elements).
+@inline
+fun _string_eq(a: string, b: string) -> bool {
+    let a_len = __heap_load(a, 1);
+    let b_len = __heap_load(b, 1);
+    if a_len != b_len {
+        return false;
+    }
+    let a_ptr = __heap_load(a, 0);
+    let b_ptr = __heap_load(b, 0);
+    let i = 0;
+    while i < a_len {
+        if __heap_load(a_ptr, i) != __heap_load(b_ptr, i) {
+            return false;
+        }
+        i = i + 1;
+    }
+    return true;
+}
+
 // Concatenate two strings by copying character data into a new string.
 @inline
 fun string_concat(a: string, b: string) -> string {


### PR DESCRIPTION
## Summary
- Phase 3 of #144: 文字列比較をVMのObjectKindチェックからstd関数呼び出しに移行
- `std/prelude.mc` に `_string_eq(a, b)` を追加（長さ比較 → データ配列の要素ごと比較）
- desugar フェーズで `BinaryOp::Eq`/`Ne` のオペランドが `string` 型の場合、`_string_eq` 呼び出しに展開
  - `a == b` → `_string_eq(a, b)`
  - `a != b` → `!_string_eq(a, b)`
- `any` 型同士の比較は従来通り VM の `values_equal()` を通る

## Test plan
- [x] `cargo fmt` / `cargo check` / `cargo test` / `cargo clippy` 全パス
- [x] 既存の全スナップショットテストが通過（文字列比較を含むテストも問題なし）

🤖 Generated with [Claude Code](https://claude.ai/code)