### PR TITLE
feat: add string field access (s.data, s.len)

### DIFF
--- a/src/compiler/typechecker.rs
+++ b/src/compiler/typechecker.rs
@@ -1468,6 +1468,17 @@ impl TypeChecker {
                         ));
                         self.fresh_var()
                     }
+                    Type::String => match field.as_str() {
+                        "data" => Type::Ptr(Box::new(Type::Int)),
+                        "len" => Type::Int,
+                        _ => {
+                            self.errors.push(TypeError::new(
+                                format!("string has no field `{}`", field),
+                                *span,
+                            ));
+                            self.fresh_var()
+                        }
+                    },
                     Type::Var(_) => {
                         // Can't infer field access on unknown object type
                         self.fresh_var()

--- a/std/prelude.mc
+++ b/std/prelude.mc
@@ -169,11 +169,11 @@ fun _int_write_to(buf: ptr<int>, off: int, n: int) -> int {
 // Copy string data into buf at offset, return new offset.
 @inline
 fun _str_copy_to(buf: ptr<int>, off: int, s: string) -> int {
-    let sptr = __heap_load(s, 0);
-    let slen = __heap_load(s, 1);
+    let sptr = s.data;
+    let slen = s.len;
     let j = 0;
     while j < slen {
-        buf[off + j] = __heap_load(sptr, j);
+        buf[off + j] = sptr[j];
         j = j + 1;
     }
     return off + slen;
@@ -745,19 +745,19 @@ fun time_format(epoch_secs: int) -> string {
 // Concatenate two strings by copying character data into a new string.
 @inline
 fun string_concat(a: string, b: string) -> string {
-    let a_ptr = __heap_load(a, 0);
-    let a_len = __heap_load(a, 1);
-    let b_ptr = __heap_load(b, 0);
-    let b_len = __heap_load(b, 1);
+    let a_ptr = a.data;
+    let a_len = a.len;
+    let b_ptr = b.data;
+    let b_len = b.len;
     let total = a_len + b_len;
     let data = __alloc_heap(total);
     let i = 0;
     while i < a_len {
-        data[i] = __heap_load(a_ptr, i);
+        data[i] = a_ptr[i];
         i = i + 1;
     }
     while i < total {
-        data[i] = __heap_load(b_ptr, i - a_len);
+        data[i] = b_ptr[i - a_len];
         i = i + 1;
     }
     return __alloc_string(data, total);
@@ -779,11 +779,11 @@ fun string_join(parts: array<string>) -> string {
     i = 0;
     while i < n {
         let s = parts[i];
-        let s_ptr = __heap_load(s, 0);
-        let s_len = __heap_load(s, 1);
+        let s_ptr = s.data;
+        let s_len = s.len;
         let j = 0;
         while j < s_len {
-            data[off] = __heap_load(s_ptr, j);
+            data[off] = s_ptr[j];
             off = off + 1;
             j = j + 1;
         }


### PR DESCRIPTION
## Summary
- string 型にフィールドアクセスを追加: `s.data` → `ptr<int>`、`s.len` → `int`
- typechecker で `Type::String` のフィールド解決を追加
- desugar で `s.data` → `__heap_load(s, 0)`、`s.len` → `__heap_load(s, 1)` に展開
- prelude.mc の `_str_copy_to`、`string_concat`、`string_join` を `s.data` / `s.len` + インデックスアクセスに書き換え
- `s.data` は `ptr<int>` 型なので `s.data[i]` でデータ要素に型安全にアクセス可能

## Test plan
- [x] `cargo fmt` / `cargo check` / `cargo test` / `cargo clippy` 全パス
- [x] 既存の全スナップショットテスト通過

🤖 Generated with [Claude Code](https://claude.ai/code)