### PR TITLE
feat: プリミティブ型への impl ブロック対応 + to_string メソッド化

### DIFF
--- a/examples/cli_args.mc
+++ b/examples/cli_args.mc
@@ -10,7 +10,7 @@ fun main() {
 
     let i = 1;
     while i < argc() {
-        print("argv(" + to_string(i) + "): ");
+        print("argv(" + i.to_string() + "): ");
         print(argv(i));
         i = i + 1;
     }
@@ -19,7 +19,7 @@ fun main() {
     let all_args = args();
     let j = 0;
     while j < len(all_args) {
-        print("  [" + to_string(j) + "] = " + all_args[j]);
+        print("  [" + j.to_string() + "] = " + all_args[j]);
         j = j + 1;
     }
 }

--- a/examples/http_get.mc
+++ b/examples/http_get.mc
@@ -13,7 +13,7 @@ fun main() {
     let port = parse_int(argv(2));
     let path = argv(3);
 
-    print("Connecting to " + host + ":" + to_string(port) + path);
+    print("Connecting to " + host + ":" + port.to_string() + path);
 
     // Create TCP socket
     let fd = socket(AF_INET(), SOCK_STREAM());

--- a/examples/http_server.mc
+++ b/examples/http_server.mc
@@ -9,7 +9,7 @@ fun main() {
         port = parse_int(argv(1));
     }
 
-    print("Starting HTTP server on port " + to_string(port));
+    print("Starting HTTP server on port " + port.to_string());
 
     // Create TCP socket
     let fd = socket(AF_INET(), SOCK_STREAM());
@@ -21,7 +21,7 @@ fun main() {
     // Bind to address
     let bind_result = bind(fd, "0.0.0.0", port);
     if bind_result < 0 {
-        print("Error: Failed to bind to port " + to_string(port));
+        print("Error: Failed to bind to port " + port.to_string());
         if bind_result == EADDRINUSE() {
             print("  Port is already in use");
         }
@@ -37,7 +37,7 @@ fun main() {
         return 1;
     }
 
-    print("Server listening on http://0.0.0.0:" + to_string(port));
+    print("Server listening on http://0.0.0.0:" + port.to_string());
     print("Press Ctrl+C to stop");
 
     // Accept and handle connections in a loop
@@ -51,7 +51,7 @@ fun main() {
             print("Error: Failed to accept connection");
             running = false;
         } else {
-            print("Client connected (fd=" + to_string(client_fd) + ")");
+            print("Client connected (fd=" + client_fd.to_string() + ")");
 
             // Read the HTTP request
             let request = read(client_fd, 4096);
@@ -62,7 +62,7 @@ fun main() {
             let body = "Hello, World!\n";
             let response = "HTTP/1.1 200 OK\r\n" +
                           "Content-Type: text/plain\r\n" +
-                          "Content-Length: " + to_string(len(body)) + "\r\n" +
+                          "Content-Length: " + len(body).to_string() + "\r\n" +
                           "Connection: close\r\n" +
                           "\r\n" +
                           body;

--- a/src/compiler/desugar.rs
+++ b/src/compiler/desugar.rs
@@ -37,39 +37,20 @@ impl Desugar {
         name
     }
 
-    /// Specialize a `to_string(x)` call based on the argument's inferred type.
-    /// Returns a type-specific call (e.g., `_int_to_string(x)`) or identity for strings.
-    fn specialize_to_string(arg: Expr, arg_type: Option<&Type>, span: Span) -> Expr {
-        match arg_type {
-            Some(Type::String) => arg,
-            Some(Type::Int) => Expr::Call {
-                callee: "_int_to_string".to_string(),
-                type_args: vec![],
-                args: vec![arg],
-                span,
-                inferred_type: Some(Type::String),
-            },
-            Some(Type::Float) => Expr::Call {
-                callee: "_float_to_string".to_string(),
-                type_args: vec![],
-                args: vec![arg],
-                span,
-                inferred_type: Some(Type::String),
-            },
-            Some(Type::Bool) => Expr::Call {
-                callee: "_bool_to_string".to_string(),
-                type_args: vec![],
-                args: vec![arg],
-                span,
-                inferred_type: Some(Type::String),
-            },
-            _ => Expr::Call {
-                callee: "to_string".to_string(),
-                type_args: vec![],
-                args: vec![arg],
-                span,
-                inferred_type: Some(Type::String),
-            },
+    /// Convert an expression to string via `.to_string()` method call.
+    /// For strings, returns the expression as-is (identity).
+    fn to_string_method_call(arg: Expr, arg_type: Option<&Type>, span: Span) -> Expr {
+        if matches!(arg_type, Some(Type::String)) {
+            return arg;
+        }
+        Expr::MethodCall {
+            object: Box::new(arg),
+            method: "to_string".to_string(),
+            type_args: vec![],
+            args: vec![],
+            span,
+            object_type: arg_type.cloned(),
+            inferred_type: Some(Type::String),
         }
     }
 
@@ -633,29 +614,20 @@ impl Desugar {
                 }
             }
 
-            // Call - desugar arguments, specialize to_string by argument type
+            // Call - desugar arguments
             Expr::Call {
                 callee,
                 type_args,
                 args,
                 span,
                 inferred_type,
-            } => {
-                // Specialize to_string(x) based on argument type
-                if callee == "to_string" && args.len() == 1 {
-                    let arg = self.desugar_expr(args.into_iter().next().unwrap());
-                    let arg_type = arg.inferred_type().cloned();
-                    return Self::specialize_to_string(arg, arg_type.as_ref(), span);
-                }
-
-                Expr::Call {
-                    callee,
-                    type_args,
-                    args: args.into_iter().map(|e| self.desugar_expr(e)).collect(),
-                    span,
-                    inferred_type,
-                }
-            }
+            } => Expr::Call {
+                callee,
+                type_args,
+                args: args.into_iter().map(|e| self.desugar_expr(e)).collect(),
+                span,
+                inferred_type,
+            },
 
             // Struct literal - desugar field values
             Expr::StructLiteral {
@@ -836,7 +808,7 @@ impl Desugar {
                             },
                             InterpPart::TypedExpr(expr, Some(Type::String)) => *expr,
                             InterpPart::TypedExpr(expr, ref ty) => {
-                                Self::specialize_to_string(*expr, ty.as_ref(), span)
+                                Self::to_string_method_call(*expr, ty.as_ref(), span)
                             }
                         })
                         .collect();
@@ -952,15 +924,18 @@ impl Desugar {
                             part_infos.push(PartInfo::Float(var));
                         }
                         _ => {
-                            // Unknown type: fallback to to_string
+                            // Unknown type: fallback to .to_string() method call
+                            let obj_type = ty.clone();
                             stmts.push(Statement::Let {
                                 name: var.clone(),
                                 type_annotation: None,
-                                init: Expr::Call {
-                                    callee: "to_string".to_string(),
+                                init: Expr::MethodCall {
+                                    object: Box::new(expr),
+                                    method: "to_string".to_string(),
                                     type_args: vec![],
-                                    args: vec![expr],
+                                    args: vec![],
                                     span,
+                                    object_type: obj_type,
                                     inferred_type: Some(Type::String),
                                 },
                                 span,

--- a/std/prelude.mc
+++ b/std/prelude.mc
@@ -640,44 +640,50 @@ fun _bool_to_string(b: bool) -> string {
     return "false";
 }
 
-// Convert any value to its string representation.
-fun to_string(x: any) -> string {
-    let t = type_of(x);
-    if t == "string" {
-        return x;
+impl int {
+    fun to_string(self) -> string {
+        return _int_to_string(self);
     }
-    if t == "int" {
-        return _int_to_string(x);
+}
+
+impl float {
+    fun to_string(self) -> string {
+        return _float_to_string(self);
     }
-    if t == "float" {
-        return _float_to_string(x);
+}
+
+impl bool {
+    fun to_string(self) -> string {
+        return _bool_to_string(self);
     }
-    if t == "bool" {
-        return _bool_to_string(x);
+}
+
+impl string {
+    fun to_string(self) -> string {
+        return self;
     }
-    return "nil";
 }
 
 // Zero-pad an integer to 2 digits.
 fun _pad2(n: int) -> string {
     if n < 10 {
-        return "0" + to_string(n);
+        return "0" + n.to_string();
     }
-    return to_string(n);
+    return n.to_string();
 }
 
 // Zero-pad an integer to 4 digits.
 fun _pad4(n: int) -> string {
     if n < 10 {
-        return "000" + to_string(n);
+        return "000" + n.to_string();
     }
     if n < 100 {
-        return "00" + to_string(n);
+        return "00" + n.to_string();
     }
     if n < 1000 {
-        return "0" + to_string(n);
+        return "0" + n.to_string();
     }
-    return to_string(n);
+    return n.to_string();
 }
 
 // Check if a year is a leap year.
@@ -843,7 +849,7 @@ fun assert(condition: bool, msg: string) {
 // Uses to_string for comparison, so works with any type that can be converted to string.
 fun assert_eq(actual: int, expected: int, msg: string) {
     if actual != expected {
-        throw msg + " (expected: " + to_string(expected) + ", actual: " + to_string(actual) + ")";
+        throw msg + " (expected: " + expected.to_string() + ", actual: " + actual.to_string() + ")";
     }
 }
 
@@ -857,7 +863,7 @@ fun assert_eq_str(actual: string, expected: string, msg: string) {
 // Assert that two booleans are equal.
 fun assert_eq_bool(actual: bool, expected: bool, msg: string) {
     if actual != expected {
-        throw msg + " (expected: " + to_string(expected) + ", actual: " + to_string(actual) + ")";
+        throw msg + " (expected: " + expected.to_string() + ", actual: " + actual.to_string() + ")";
     }
 }
 

--- a/std/prelude_test.mc
+++ b/std/prelude_test.mc
@@ -158,7 +158,7 @@ fun _test_rand_int_distribution() {
 
     // max/min <= 1.2  <=>  max * 5 <= min * 6
     assert(max_count * 5 <= min_count * 6,
-        "rand_int distribution: max/min ratio should be within 20% (max=" + to_string(max_count) + ", min=" + to_string(min_count) + ")");
+        "rand_int distribution: max/min ratio should be within 20% (max=" + max_count.to_string() + ", min=" + min_count.to_string() + ")");
 }
 
 // Generate rand_float() 10000 times into 10 buckets and check frequency uniformity (max/min <= 1.2)
@@ -187,7 +187,7 @@ fun _test_rand_float_distribution() {
 
     // max/min <= 1.2  <=>  max * 5 <= min * 6
     assert(max_count * 5 <= min_count * 6,
-        "rand_float distribution: max/min ratio should be within 20% (max=" + to_string(max_count) + ", min=" + to_string(min_count) + ")");
+        "rand_float distribution: max/min ratio should be within 20% (max=" + max_count.to_string() + ", min=" + min_count.to_string() + ")");
 }
 
 // ============================================================================
@@ -200,7 +200,7 @@ fun _assert_sorted_int(v: Vec<int>, msg: string) {
     let i = 0;
     while i < n - 1 {
         assert(v[i] <= v[i + 1],
-            msg + " (v[" + to_string(i) + "]=" + to_string(v[i]) + " > v[" + to_string(i + 1) + "]=" + to_string(v[i + 1]) + ")");
+            msg + " (v[" + i.to_string() + "]=" + v[i].to_string() + " > v[" + (i + 1).to_string() + "]=" + v[i + 1].to_string() + ")");
         i = i + 1;
     }
 }
@@ -210,7 +210,7 @@ fun _assert_sorted_float(v: Vec<float>, msg: string) {
     let n = v.len();
     let i = 0;
     while i < n - 1 {
-        assert(v[i] <= v[i + 1], msg + " (index " + to_string(i) + ")");
+        assert(v[i] <= v[i + 1], msg + " (index " + i.to_string() + ")");
         i = i + 1;
     }
 }

--- a/tests/snapshots/basic/builtin_functions.mc
+++ b/tests/snapshots/basic/builtin_functions.mc
@@ -7,10 +7,10 @@ print(type_of("hello"));
 print(type_of([1, 2, 3]));
 
 // to_string
-print(to_string(42));
-print(to_string(3.14));
-print(to_string(true));
-print(to_string(nil));
+print(42.to_string());
+print(3.14.to_string());
+print(true.to_string());
+print("nil");
 
 // parse_int
 let n = parse_int("42");

--- a/tests/snapshots/basic/float_ryu.mc
+++ b/tests/snapshots/basic/float_ryu.mc
@@ -57,8 +57,8 @@ print($"{1.5e2}");
 print($"{3.14e5}");
 
 // to_string for floats
-print($"{to_string(3.14)}");
-print($"{to_string(0.0)}");
-print($"{to_string(100000000000000000.0)}");
-print($"{to_string(0.0000001)}");
-print($"{to_string(-42.5)}");
+print($"{3.14.to_string()}");
+print($"{0.0.to_string()}");
+print($"{100000000000000000.0.to_string()}");
+print($"{0.0000001.to_string()}");
+print($"{(-42.5).to_string()}");

--- a/tests/snapshots/basic/text_counting.mc
+++ b/tests/snapshots/basic/text_counting.mc
@@ -53,7 +53,7 @@ fun count_chars() {
             }
             j = j + 1;
         }
-        print(labels[max_idx] + ": " + to_string(max_val));
+        print(labels[max_idx] + ": " + max_val.to_string());
         counts[max_idx] = 0 - 1;
         rank = rank + 1;
     }

--- a/tests/snapshots/basic/to_string.mc
+++ b/tests/snapshots/basic/to_string.mc
@@ -1,29 +1,29 @@
 // to_string with various types
 
 // int
-print(to_string(0));
-print(to_string(1));
-print(to_string(-1));
-print(to_string(42));
-print(to_string(-999));
-print(to_string(1000000));
+print(0.to_string());
+print(1.to_string());
+print((-1).to_string());
+print(42.to_string());
+print((-999).to_string());
+print(1000000.to_string());
 
 // float
-print(to_string(0.0));
-print(to_string(3.14));
-print(to_string(-2.5));
-print(to_string(1.0));
+print(0.0.to_string());
+print(3.14.to_string());
+print((-2.5).to_string());
+print(1.0.to_string());
 
 // bool
-print(to_string(true));
-print(to_string(false));
+print(true.to_string());
+print(false.to_string());
 
 // nil
-print(to_string(nil));
+print("nil");
 
 // string (identity)
-print(to_string("hello"));
-print(to_string(""));
+print("hello");
+print("");
 
 // used in string interpolation
 let x = 42;
@@ -32,6 +32,6 @@ let b = true;
 print($"int={x}, float={y}, bool={b}");
 
 // edge cases for int
-print(to_string(10));
-print(to_string(100));
-print(to_string(-10));
+print(10.to_string());
+print(100.to_string());
+print((-10).to_string());

--- a/tests/snapshots/http/http_post_echo.mc.template
+++ b/tests/snapshots/http/http_post_echo.mc.template
@@ -78,7 +78,7 @@ if fd >= 0 {
     if result >= 0 {
         // Build HTTP POST request with JSON body
         let body = "{\"x\":123}";
-        let headers = "POST /echo HTTP/1.1\r\nHost: localhost\r\nContent-Type: application/json\r\nContent-Length: " + to_string(len(body)) + "\r\nConnection: close\r\n\r\n";
+        let headers = "POST /echo HTTP/1.1\r\nHost: localhost\r\nContent-Type: application/json\r\nContent-Length: " + len(body).to_string() + "\r\nConnection: close\r\n\r\n";
         let request = headers + body;
         let written = write(fd, request, len(request));
 

--- a/tests/snapshots/performance/text_counting.mc
+++ b/tests/snapshots/performance/text_counting.mc
@@ -58,7 +58,7 @@ fun count_chars() {
             }
             j = j + 1;
         }
-        print(labels[max_idx] + ": " + to_string(max_val));
+        print(labels[max_idx] + ": " + max_val.to_string());
         counts[max_idx] = 0 - 1;
         rank = rank + 1;
     }


### PR DESCRIPTION
## Summary

- プリミティブ型（`int`, `float`, `bool`, `string`）に `impl` ブロックを定義可能にし、`x.to_string()` メソッド呼び出しを実現
- `to_string(x: any)` フリー関数と desugar の `specialize_to_string` を廃止し、型チェッカーが自然にメソッドを解決する設計に統一
- 全 `.mc` ファイルの `to_string(x)` 呼び出しを `x.to_string()` に移行

## Changes

### Compiler
- **typechecker**: `primitive_methods` マップを導入。プリミティブ型の impl ブロック登録（`register_impl_methods`）、メソッド呼び出し型チェック（`check_primitive_method`）を追加
- **resolver**: プリミティブ型のメソッドを `func_index` にマッピングする仕組みを追加。`object_type`（typechecker が設定）を利用して解決
- **desugar**: `specialize_to_string` を廃止し `to_string_method_call` に置換。文字列補間の 3+ パート最適化（`desugar_string_interp_direct`）は維持

### Standard Library
- **prelude.mc**: `impl int/float/bool/string { fun to_string(self) -> string }` を追加、`to_string(x: any)` フリー関数を削除

### Migration
- 全 `.mc` ファイル（examples, tests, std）の `to_string(x)` → `x.to_string()` に移行
- `to_string(nil)` → `"nil"` に置換（nil 型にはメソッド呼び出し不可）

## Test plan
- [x] `cargo fmt` — pass
- [x] `cargo check` — pass
- [x] `cargo test` — 全 347 テスト pass（スナップショット出力変更なし）
- [x] `cargo clippy` — pass
- [x] `moca lint std/prelude.mc` — 既存警告のみ（本変更に無関係）

Closes #149

🤖 Generated with [Claude Code](https://claude.ai/code)