### PR TITLE
feat: Mapヘルパー関数をメソッドに変換しMap<any,any>を除去

### DIFF
--- a/src/compiler/typechecker.rs
+++ b/src/compiler/typechecker.rs
@@ -3123,6 +3123,49 @@ impl TypeChecker {
                 }
                 Type::Int
             }
+            "_find_entry_int" => {
+                // _find_entry_int(key: int) -> int (internal)
+                if args.len() != 1 {
+                    self.errors.push(TypeError::new(
+                        format!("map._find_entry_int expects 1 argument, got {}", args.len()),
+                        span,
+                    ));
+                    return Type::Int;
+                }
+                let k_type = self.infer_expr(&mut args[0], env);
+                if let Err(e) = self.unify(&k_type, &Type::Int, args[0].span()) {
+                    self.errors.push(e);
+                }
+                Type::Int
+            }
+            "_find_entry_string" => {
+                // _find_entry_string(key: string) -> int (internal)
+                if args.len() != 1 {
+                    self.errors.push(TypeError::new(
+                        format!(
+                            "map._find_entry_string expects 1 argument, got {}",
+                            args.len()
+                        ),
+                        span,
+                    ));
+                    return Type::Int;
+                }
+                let k_type = self.infer_expr(&mut args[0], env);
+                if let Err(e) = self.unify(&k_type, &Type::String, args[0].span()) {
+                    self.errors.push(e);
+                }
+                Type::Int
+            }
+            "_rehash_int" | "_rehash_string" => {
+                // _rehash_int() / _rehash_string() (internal)
+                if !args.is_empty() {
+                    self.errors.push(TypeError::new(
+                        format!("map.{} expects 0 arguments, got {}", method, args.len()),
+                        span,
+                    ));
+                }
+                Type::Nil
+            }
             _ => {
                 self.errors.push(TypeError::new(
                     format!(


### PR DESCRIPTION
## Summary

- `_map_find_entry_int/string` と `_map_rehash_int/string` をフリー関数から `impl<K,V> Map<K,V>` のメソッドに変換
- パラメータの `Map<any, any>` を `self` に置換し、`any` 型の使用を4箇所削除
- `typechecker.rs` の `check_map_method` に内部メソッド（`_find_entry_int/string`, `_rehash_int/string`）を登録

## 変更ファイル

- `std/prelude.mc`: ヘルパー関数を impl ブロック内のメソッドに移動、呼び出し側を `self.method()` 形式に変更
- `src/compiler/typechecker.rs`: `check_map_method` にメソッドの型情報を追加

## Test plan

- [x] `cargo test --no-default-features` で全スナップショットテストパス
- [x] `cargo clippy --no-default-features` 新規警告なし
- [x] `moca lint std/prelude.mc` 警告なし

Closes #160

🤖 Generated with [Claude Code](https://claude.ai/code)