### PR TITLE
feat: 型別print/equality命令の追加 (Phase 5)

### DIFF
--- a/src/compiler/dump.rs
+++ b/src/compiler/dump.rs
@@ -1727,6 +1727,12 @@ impl<'a> Disassembler<'a> {
             Op::Syscall(num, argc) => self.output.push_str(&format!("Syscall {} {}", num, argc)),
             Op::GcHint(size) => self.output.push_str(&format!("GcHint {}", size)),
             Op::PrintDebug => self.output.push_str("PrintDebug"),
+            Op::PrintI64 => self.output.push_str("PrintI64"),
+            Op::PrintF64 => self.output.push_str("PrintF64"),
+            Op::PrintBool => self.output.push_str("PrintBool"),
+            Op::PrintString => self.output.push_str("PrintString"),
+            Op::PrintNil => self.output.push_str("PrintNil"),
+            Op::StringEq => self.output.push_str("StringEq"),
             Op::TypeOf => self.output.push_str("TypeOf"),
             Op::FloatToString => self.output.push_str("ToString"),
             Op::ParseInt => self.output.push_str("ParseInt"),
@@ -2286,6 +2292,37 @@ fn format_single_microop(output: &mut String, mop: &MicroOp, chunk: &Chunk) {
             "PrintDebug {}, {}",
             format_vreg(dst),
             format_vreg(src)
+        )),
+        MicroOp::PrintI64 { dst, src } => output.push_str(&format!(
+            "PrintI64 {}, {}",
+            format_vreg(dst),
+            format_vreg(src)
+        )),
+        MicroOp::PrintF64 { dst, src } => output.push_str(&format!(
+            "PrintF64 {}, {}",
+            format_vreg(dst),
+            format_vreg(src)
+        )),
+        MicroOp::PrintBool { dst, src } => output.push_str(&format!(
+            "PrintBool {}, {}",
+            format_vreg(dst),
+            format_vreg(src)
+        )),
+        MicroOp::PrintString { dst, src } => output.push_str(&format!(
+            "PrintString {}, {}",
+            format_vreg(dst),
+            format_vreg(src)
+        )),
+        MicroOp::PrintNil { dst, src } => output.push_str(&format!(
+            "PrintNil {}, {}",
+            format_vreg(dst),
+            format_vreg(src)
+        )),
+        MicroOp::StringEq { dst, a, b } => output.push_str(&format!(
+            "StringEq {}, {}, {}",
+            format_vreg(dst),
+            format_vreg(a),
+            format_vreg(b)
         )),
         // Stack bridge
         MicroOp::StackPush { src } => output.push_str(&format!("StackPush {}", format_vreg(src))),

--- a/src/vm/bytecode.rs
+++ b/src/vm/bytecode.rs
@@ -415,6 +415,14 @@ const OP_F64_REINTERPRET_AS_I64: u8 = 116;
 const OP_UMUL128_HI: u8 = 117;
 const OP_HEAP_OFFSET_REF: u8 = 118;
 
+// Type-specific print / equality (Phase 5)
+const OP_PRINT_I64: u8 = 119;
+const OP_PRINT_F64: u8 = 120;
+const OP_PRINT_BOOL: u8 = 121;
+const OP_PRINT_STRING: u8 = 122;
+const OP_PRINT_NIL: u8 = 123;
+const OP_STRING_EQ: u8 = 124;
+
 fn write_op<W: Write>(w: &mut W, op: &Op) -> io::Result<()> {
     match op {
         // Constants
@@ -604,6 +612,12 @@ fn write_op<W: Write>(w: &mut W, op: &Op) -> io::Result<()> {
             write_u32(w, *size as u32)?;
         }
         Op::PrintDebug => w.write_all(&[OP_PRINT_DEBUG])?,
+        Op::PrintI64 => w.write_all(&[OP_PRINT_I64])?,
+        Op::PrintF64 => w.write_all(&[OP_PRINT_F64])?,
+        Op::PrintBool => w.write_all(&[OP_PRINT_BOOL])?,
+        Op::PrintString => w.write_all(&[OP_PRINT_STRING])?,
+        Op::PrintNil => w.write_all(&[OP_PRINT_NIL])?,
+        Op::StringEq => w.write_all(&[OP_STRING_EQ])?,
         Op::TypeOf => w.write_all(&[OP_TYPE_OF])?,
         Op::FloatToString => w.write_all(&[OP_FLOAT_TO_STRING])?,
         Op::ParseInt => w.write_all(&[OP_PARSE_INT])?,
@@ -780,6 +794,12 @@ fn read_op<R: Read>(r: &mut R) -> Result<Op, BytecodeError> {
         OP_SYSCALL => Op::Syscall(read_u32(r)? as usize, read_u32(r)? as usize),
         OP_GC_HINT => Op::GcHint(read_u32(r)? as usize),
         OP_PRINT_DEBUG => Op::PrintDebug,
+        OP_PRINT_I64 => Op::PrintI64,
+        OP_PRINT_F64 => Op::PrintF64,
+        OP_PRINT_BOOL => Op::PrintBool,
+        OP_PRINT_STRING => Op::PrintString,
+        OP_PRINT_NIL => Op::PrintNil,
+        OP_STRING_EQ => Op::StringEq,
         OP_TYPE_OF => Op::TypeOf,
         OP_FLOAT_TO_STRING => Op::FloatToString,
         OP_PARSE_INT => Op::ParseInt,
@@ -1208,6 +1228,12 @@ mod tests {
             Op::Syscall(7, 2),
             Op::GcHint(1024),
             Op::PrintDebug,
+            Op::PrintI64,
+            Op::PrintF64,
+            Op::PrintBool,
+            Op::PrintString,
+            Op::PrintNil,
+            Op::StringEq,
             Op::TypeOf,
             Op::FloatToString,
             Op::ParseInt,

--- a/src/vm/microop.rs
+++ b/src/vm/microop.rs
@@ -497,6 +497,37 @@ pub enum MicroOp {
         dst: VReg,
         src: VReg,
     },
+    /// Type-specific print: print i64 value
+    PrintI64 {
+        dst: VReg,
+        src: VReg,
+    },
+    /// Type-specific print: print f64 value
+    PrintF64 {
+        dst: VReg,
+        src: VReg,
+    },
+    /// Type-specific print: print bool value
+    PrintBool {
+        dst: VReg,
+        src: VReg,
+    },
+    /// Type-specific print: print string value
+    PrintString {
+        dst: VReg,
+        src: VReg,
+    },
+    /// Type-specific print: print nil
+    PrintNil {
+        dst: VReg,
+        src: VReg,
+    },
+    /// Content-based string equality
+    StringEq {
+        dst: VReg,
+        a: VReg,
+        b: VReg,
+    },
     // ========================================
     // Stack Bridge (for Raw op interop)
     // ========================================

--- a/src/vm/microop_converter.rs
+++ b/src/vm/microop_converter.rs
@@ -1723,6 +1723,102 @@ pub fn convert(func: &Function) -> ConvertedFunction {
                 micro_ops.push(MicroOp::PrintDebug { dst, src });
                 vstack.push(Vse::Reg(dst));
             }
+            Op::PrintI64 => {
+                let src = pop_vreg(
+                    &mut vstack,
+                    &mut micro_ops,
+                    &mut next_temp,
+                    &mut max_temp,
+                    &mut vreg_types,
+                );
+                let dst = alloc_temp(
+                    &mut next_temp,
+                    &mut max_temp,
+                    &mut vreg_types,
+                    ValueType::I64,
+                );
+                micro_ops.push(MicroOp::PrintI64 { dst, src });
+                vstack.push(Vse::Reg(dst));
+            }
+            Op::PrintF64 => {
+                let src = pop_vreg(
+                    &mut vstack,
+                    &mut micro_ops,
+                    &mut next_temp,
+                    &mut max_temp,
+                    &mut vreg_types,
+                );
+                let dst = alloc_temp(
+                    &mut next_temp,
+                    &mut max_temp,
+                    &mut vreg_types,
+                    ValueType::F64,
+                );
+                micro_ops.push(MicroOp::PrintF64 { dst, src });
+                vstack.push(Vse::RegF64(dst));
+            }
+            Op::PrintBool => {
+                let src = pop_vreg(
+                    &mut vstack,
+                    &mut micro_ops,
+                    &mut next_temp,
+                    &mut max_temp,
+                    &mut vreg_types,
+                );
+                let dst = alloc_temp(
+                    &mut next_temp,
+                    &mut max_temp,
+                    &mut vreg_types,
+                    ValueType::I32,
+                );
+                micro_ops.push(MicroOp::PrintBool { dst, src });
+                vstack.push(Vse::Reg(dst));
+            }
+            Op::PrintString => {
+                let src = pop_vreg(
+                    &mut vstack,
+                    &mut micro_ops,
+                    &mut next_temp,
+                    &mut max_temp,
+                    &mut vreg_types,
+                );
+                let dst = alloc_temp(
+                    &mut next_temp,
+                    &mut max_temp,
+                    &mut vreg_types,
+                    ValueType::Ref,
+                );
+                micro_ops.push(MicroOp::PrintString { dst, src });
+                vstack.push(Vse::RegRef(dst));
+            }
+            Op::PrintNil => {
+                let src = pop_vreg(
+                    &mut vstack,
+                    &mut micro_ops,
+                    &mut next_temp,
+                    &mut max_temp,
+                    &mut vreg_types,
+                );
+                let dst = alloc_temp(
+                    &mut next_temp,
+                    &mut max_temp,
+                    &mut vreg_types,
+                    ValueType::Ref,
+                );
+                micro_ops.push(MicroOp::PrintNil { dst, src });
+                vstack.push(Vse::RegRef(dst));
+            }
+            Op::StringEq => {
+                emit_binop(
+                    &mut vstack,
+                    &mut micro_ops,
+                    &mut next_temp,
+                    &mut max_temp,
+                    &mut vreg_types,
+                    ValueType::I64,
+                    |dst, a, b| MicroOp::StringEq { dst, a, b },
+                );
+            }
 
             // ============================================================
             // Heap allocation operations
@@ -2092,7 +2188,14 @@ fn try_patch_dst(mop: &mut MicroOp, new_dst: VReg) -> Option<VReg> {
         | MicroOp::I64TruncF32S { dst, .. }
         | MicroOp::F32DemoteF64 { dst, .. }
         | MicroOp::F64PromoteF32 { dst, .. }
-        | MicroOp::F64ReinterpretAsI64 { dst, .. } => {
+        | MicroOp::F64ReinterpretAsI64 { dst, .. }
+        // Type-specific print / equality
+        | MicroOp::PrintI64 { dst, .. }
+        | MicroOp::PrintF64 { dst, .. }
+        | MicroOp::PrintBool { dst, .. }
+        | MicroOp::PrintString { dst, .. }
+        | MicroOp::PrintNil { dst, .. }
+        | MicroOp::StringEq { dst, .. } => {
             let old = *dst;
             *dst = new_dst;
             Some(old)

--- a/src/vm/ops.rs
+++ b/src/vm/ops.rs
@@ -176,6 +176,18 @@ pub enum Op {
     Syscall(usize, usize),
     GcHint(usize),
     PrintDebug,
+    /// Type-specific print: print i64 value without ObjectKind dispatch
+    PrintI64,
+    /// Type-specific print: print f64 value without ObjectKind dispatch
+    PrintF64,
+    /// Type-specific print: print bool value without ObjectKind dispatch
+    PrintBool,
+    /// Type-specific print: print string value without ObjectKind dispatch
+    PrintString,
+    /// Type-specific print: print nil without ObjectKind dispatch
+    PrintNil,
+    /// Content-based string equality without ObjectKind dispatch
+    StringEq,
     TypeOf,
     FloatToString,
     ParseInt,
@@ -317,6 +329,12 @@ impl Op {
             Op::Syscall(_, _) => "Syscall",
             Op::GcHint(_) => "GcHint",
             Op::PrintDebug => "PrintDebug",
+            Op::PrintI64 => "PrintI64",
+            Op::PrintF64 => "PrintF64",
+            Op::PrintBool => "PrintBool",
+            Op::PrintString => "PrintString",
+            Op::PrintNil => "PrintNil",
+            Op::StringEq => "StringEq",
             Op::TypeOf => "TypeOf",
             Op::FloatToString => "FloatToString",
             Op::ParseInt => "ParseInt",

--- a/src/vm/verifier.rs
+++ b/src/vm/verifier.rs
@@ -468,7 +468,9 @@ impl Verifier {
             // System / Builtins
             Op::Syscall(_, argc) => (*argc, 1), // pops argc args, pushes result
             Op::GcHint(_) => (0, 0),
-            Op::PrintDebug => (1, 1),    // pops value, pushes return value
+            Op::PrintDebug => (1, 1), // pops value, pushes return value
+            Op::PrintI64 | Op::PrintF64 | Op::PrintBool | Op::PrintString | Op::PrintNil => (1, 1),
+            Op::StringEq => (2, 1),      // pops two refs, pushes bool
             Op::TypeOf => (1, 1),        // pops value, pushes type string
             Op::FloatToString => (1, 1), // pops value, pushes string
             Op::ParseInt => (1, 1),      // pops string, pushes int


### PR DESCRIPTION
## Summary

- `PrintI64`, `PrintF64`, `PrintBool`, `PrintString`, `PrintNil`, `StringEq` の6つの新VM命令を追加
- codegen がリテラル・比較演算など型が確実なケースで型別 print 命令を発行
- Ref型（文字列変数・メソッド呼び出し結果等）は `PrintDebug` にフォールバック
- 全実行パス対応: スタックインタプリタ、MicroOpインタプリタ、バイトコードシリアライゼーション

## Test plan

- [x] `cargo fmt` — OK
- [x] `cargo check` — OK
- [x] `cargo test` — 272 lib + 15 snapshot tests pass (snapshot_jit は既知の問題)
- [x] `cargo clippy` — pre-existing warnings のみ

Closes #162

🤖 Generated with [Claude Code](https://claude.ai/code)