### PR TITLE
feat: ジェネリック関数呼び出しの型引数推論を実装

### DIFF
--- a/tests/snapshots/interface/interface_inferred_type_args.mc
+++ b/tests/snapshots/interface/interface_inferred_type_args.mc
@@ -1,0 +1,25 @@
+// Test interface-bounded generic functions with inferred type arguments
+
+interface Greet {
+    fun greet(self) -> string;
+}
+
+impl Greet for int {
+    fun greet(self) -> string {
+        return "hello from int";
+    }
+}
+
+impl Greet for string {
+    fun greet(self) -> string {
+        return "hello from string";
+    }
+}
+
+fun show_greet<T: Greet>(v: T) -> string {
+    return v.greet();
+}
+
+// Type arguments inferred (no explicit <int> or <string>)
+print(show_greet(42));
+print(show_greet("world"));

--- a/tests/snapshots/interface/interface_inferred_type_args.stdout
+++ b/tests/snapshots/interface/interface_inferred_type_args.stdout
@@ -1,0 +1,2 @@
+hello from int
+hello from string


### PR DESCRIPTION
## Summary

- typecheckerでジェネリック関数の暗黙呼び出し時に、HM推論の結果をASTの`type_args`に書き戻すことで、monomorphiseが型引数推論済みの呼び出しを正しく処理できるようにした
- `Type::to_type_annotation()` 逆変換メソッドを追加し、推論された`Type`を`TypeAnnotation`に変換
- 推論された型引数に対するinterface bounds検証も実施

```moca
fun show<T: Display>(v: T) { ... }
show(42);       // T = int と推論 → show__int を生成
show("hello");  // T = string と推論 → show__string を生成
```

Closes #175

## Test plan

- [x] 既存の `generic_function_inferred` スナップショットテストが通ること
- [x] 既存の `generic_function_multi_params` テスト（複数型パラメータ推論）が通ること
- [x] 新規 `interface_inferred_type_args` テスト（interface bounds付き推論）が通ること
- [x] `snapshot_errors` テストが通ること（既存エラーケースに影響なし）
- [x] `cargo fmt && cargo check && cargo clippy` がパスすること

🤖 Generated with [Claude Code](https://claude.ai/code)