### PR TITLE
refactor: 未使用の Type::Object を削除

### DIFF
--- a/src/compiler/codegen.rs
+++ b/src/compiler/codegen.rs
@@ -95,7 +95,6 @@ impl Codegen {
             | Type::Map(_, _)
             | Type::Struct { .. }
             | Type::GenericStruct { .. }
-            | Type::Object(_)
             | Type::Nullable(_)
             | Type::Ptr(_)
             | Type::Dyn => ValueType::Ref,

--- a/src/compiler/monomorphise.rs
+++ b/src/compiler/monomorphise.rs
@@ -65,7 +65,6 @@ fn mangle_type(ty: &Type) -> String {
         Type::Vector(elem) => format!("vec_{}", mangle_type(elem)),
         Type::Map(k, v) => format!("map_{}_{}", mangle_type(k), mangle_type(v)),
         Type::Nullable(inner) => format!("opt_{}", mangle_type(inner)),
-        Type::Object(_) => "obj".to_string(),
         Type::Function { params, ret } => {
             let params_str = params.iter().map(mangle_type).collect::<Vec<_>>().join("_");
             format!("fn_{}_{}", params_str, mangle_type(ret))
@@ -734,12 +733,6 @@ fn substitute_type_annotation(
             Box::new(substitute_type_annotation(key, type_map)),
             Box::new(substitute_type_annotation(value, type_map)),
         ),
-        TypeAnnotation::Object(fields) => TypeAnnotation::Object(
-            fields
-                .iter()
-                .map(|(name, ann)| (name.clone(), substitute_type_annotation(ann, type_map)))
-                .collect(),
-        ),
         TypeAnnotation::Nullable(inner) => {
             TypeAnnotation::Nullable(Box::new(substitute_type_annotation(inner, type_map)))
         }
@@ -782,12 +775,6 @@ fn type_to_annotation(ty: &Type) -> crate::compiler::types::TypeAnnotation {
             Box::new(type_to_annotation(value)),
         ),
         Type::Nullable(inner) => TypeAnnotation::Nullable(Box::new(type_to_annotation(inner))),
-        Type::Object(fields) => TypeAnnotation::Object(
-            fields
-                .iter()
-                .map(|(name, ty)| (name.clone(), type_to_annotation(ty)))
-                .collect(),
-        ),
         Type::Function { params, ret } => TypeAnnotation::Function {
             params: params.iter().map(type_to_annotation).collect(),
             ret: Box::new(type_to_annotation(ret)),

--- a/src/compiler/parser.rs
+++ b/src/compiler/parser.rs
@@ -748,11 +748,6 @@ impl<'a> Parser<'a> {
             return self.parse_function_type();
         }
 
-        // Check for object type: {field: T, ...}
-        if self.check(&TokenKind::LBrace) {
-            return self.parse_object_type();
-        }
-
         // Named type (int, float, bool, string, nil) or array<T>
         let name = self.expect_ident()?;
 
@@ -815,31 +810,6 @@ impl<'a> Parser<'a> {
             params,
             ret: Box::new(ret),
         })
-    }
-
-    fn parse_object_type(&mut self) -> Result<TypeAnnotation, String> {
-        self.expect(&TokenKind::LBrace)?;
-
-        let mut fields = Vec::new();
-        if !self.check(&TokenKind::RBrace) {
-            let field_name = self.expect_ident()?;
-            self.expect(&TokenKind::Colon)?;
-            let field_type = self.parse_type_annotation()?;
-            fields.push((field_name, field_type));
-
-            while self.match_token(&TokenKind::Comma) {
-                if self.check(&TokenKind::RBrace) {
-                    break; // Allow trailing comma
-                }
-                let field_name = self.expect_ident()?;
-                self.expect(&TokenKind::Colon)?;
-                let field_type = self.parse_type_annotation()?;
-                fields.push((field_name, field_type));
-            }
-        }
-        self.expect(&TokenKind::RBrace)?;
-
-        Ok(TypeAnnotation::Object(fields))
     }
 
     // Expression parsing with precedence climbing


### PR DESCRIPTION
## Summary
- `Type::Object` / `TypeAnnotation::Object`（匿名レコード型）を全コンパイラパスから削除
- 全パス（parser, typechecker, monomorphise, codegen）に実装されていたが、`.mc`ファイルで一度も使用されていなかったデッドコード
- 5ファイルから164行削除

Closes #177

## Test plan
- [x] `cargo check` パス
- [x] `cargo test` 全291テストパス
- [x] `cargo clippy` 新規警告なし

🤖 Generated with [Claude Code](https://claude.com/claude-code)