### PR TITLE
fix: unify match dyn arm types for return type inference

### DIFF
--- a/tests/snapshots/basic/dyn_match.mc
+++ b/tests/snapshots/basic/dyn_match.mc
@@ -1,0 +1,27 @@
+// Test match dyn with return in arms (requires arm type unification)
+
+fun describe(d: dyn) -> string {
+    match dyn d {
+        v: int => {
+            return "integer=" + v.to_string();
+        }
+        v: string => {
+            return "string=" + v;
+        }
+        v: bool => {
+            return "bool=" + v.to_string();
+        }
+        v: float => {
+            return "float=" + v.to_string();
+        }
+        _ => {
+            return "unknown";
+        }
+    }
+}
+
+print(describe(42 as dyn));
+print(describe("world" as dyn));
+print(describe(false as dyn));
+print(describe(2.718 as dyn));
+print(describe(nil as dyn));

--- a/tests/snapshots/basic/dyn_match.stdout
+++ b/tests/snapshots/basic/dyn_match.stdout
@@ -1,0 +1,5 @@
+integer=42
+string=world
+bool=false
+float=2.718
+unknown


### PR DESCRIPTION
## Summary

- `match dyn` の typechecker で各アーム（+ default ブロック）のブロック型を推論し、`if`/`else` と同様に型を統合（unify）するように修正
- これにより `match dyn` のアーム内で `return` を使う関数が正しく型チェックされるようになる

## Problem

Before this fix, `match dyn` always returned `Type::Nil` regardless of arm block types. This caused a type error when using `return` inside arms of a function with a declared return type:

```moca
fun describe(d: dyn) -> string {
    match dyn d {
        v: int => { return "int"; }  // ERROR: expected nil, found string
        _ => { return "unknown"; }
    }
}
```

## Solution

Collect block types from each arm and the default block, then unify them — same approach as `if`/`else` uses for `then_type`/`else_type`.

## Test plan
- [x] New snapshot test `tests/snapshots/basic/dyn_match.mc` — uses `return` in all arms of a typed function
- [x] `cargo fmt` / `cargo check` / `cargo test` / `cargo clippy` all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)