### PR TITLE
perf(vm): match dyn の型判定をポインタ比較に最適化

### DIFF
--- a/src/compiler/dump.rs
+++ b/src/compiler/dump.rs
@@ -1853,6 +1853,11 @@ impl<'a> Disassembler<'a> {
             Op::CallIndirect(argc) => {
                 self.output.push_str(&format!("CallIndirect {}", argc));
             }
+
+            // Type Descriptor
+            Op::TypeDescLoad(idx) => {
+                self.output.push_str(&format!("TypeDescLoad {}", idx));
+            }
         }
     }
 }
@@ -2347,6 +2352,19 @@ fn format_single_microop(output: &mut String, mop: &MicroOp, chunk: &Chunk) {
                 format_vreg(data_ref),
                 format_vreg(len),
                 kind_str
+            ));
+        }
+        MicroOp::TypeDescLoad { dst, idx } => {
+            let tag = chunk
+                .type_descriptors
+                .get(*idx)
+                .map(|td| td.tag_name.as_str())
+                .unwrap_or("<unknown>");
+            output.push_str(&format!(
+                "{} = TypeDescLoad {} ; \"{}\"",
+                format_vreg(dst),
+                idx,
+                tag
             ));
         }
         MicroOp::StringConst { dst, idx } => {

--- a/src/ffi/load.rs
+++ b/src/ffi/load.rs
@@ -193,6 +193,7 @@ mod tests {
                 local_types: vec![],
             },
             strings: vec![],
+            type_descriptors: vec![],
             debug: None,
         };
 
@@ -267,6 +268,7 @@ mod tests {
                 local_types: vec![],
             },
             strings: vec!["test".to_string()],
+            type_descriptors: vec![],
             debug: None,
         };
 

--- a/src/vm/microop.rs
+++ b/src/vm/microop.rs
@@ -485,6 +485,12 @@ pub enum MicroOp {
         dst: VReg,
         idx: usize,
     },
+    /// Load pre-allocated type descriptor reference.
+    /// dst = type_descriptor_refs[idx]
+    TypeDescLoad {
+        dst: VReg,
+        idx: usize,
+    },
     /// Convert value to string representation.
     /// dst = to_string(src) (Ref to newly allocated heap string)
     FloatToString {

--- a/src/vm/microop_converter.rs
+++ b/src/vm/microop_converter.rs
@@ -1665,6 +1665,16 @@ pub fn convert(func: &Function) -> ConvertedFunction {
                 micro_ops.push(MicroOp::StringConst { dst, idx: *idx });
                 vstack.push(Vse::RegRef(dst));
             }
+            Op::TypeDescLoad(idx) => {
+                let dst = alloc_temp(
+                    &mut next_temp,
+                    &mut max_temp,
+                    &mut vreg_types,
+                    ValueType::Ref,
+                );
+                micro_ops.push(MicroOp::TypeDescLoad { dst, idx: *idx });
+                vstack.push(Vse::RegRef(dst));
+            }
             Op::FloatToString => {
                 let src = pop_vreg(
                     &mut vstack,

--- a/src/vm/mod.rs
+++ b/src/vm/mod.rs
@@ -62,6 +62,15 @@ pub struct Function {
     pub local_types: Vec<ValueType>,
 }
 
+/// A type descriptor for pre-allocated dyn type info objects.
+#[derive(Debug, Clone, PartialEq)]
+pub struct TypeDescriptor {
+    /// Tag name for type matching (e.g., "int", "Point", "Vec_string")
+    pub tag_name: String,
+    /// Field names for struct types (empty for primitives)
+    pub field_names: Vec<String>,
+}
+
 /// A compiled chunk of bytecode.
 #[derive(Debug, Clone)]
 pub struct Chunk {
@@ -69,6 +78,8 @@ pub struct Chunk {
     pub main: Function,
     /// String constants pool
     pub strings: Vec<String>,
+    /// Type descriptor table for dyn type info
+    pub type_descriptors: Vec<TypeDescriptor>,
     /// Debug information (optional)
     pub debug: Option<DebugInfo>,
 }

--- a/src/vm/ops.rs
+++ b/src/vm/ops.rs
@@ -212,6 +212,13 @@ pub enum Op {
     /// Reads func_index from slot 0, extra args (captures) from slots 1..,
     /// then calls the function with (extra_args + argc) arguments.
     CallIndirect(usize), // (argc) — number of user-visible arguments
+
+    // ========================================
+    // Type Descriptor
+    // ========================================
+    /// Push pre-allocated type descriptor reference onto the stack.
+    /// The index refers to the type_descriptors table in the Chunk.
+    TypeDescLoad(usize),
 }
 
 impl Op {
@@ -333,6 +340,7 @@ impl Op {
             Op::ChannelRecv => "ChannelRecv",
             Op::ThreadJoin => "ThreadJoin",
             Op::CallIndirect(_) => "CallIndirect",
+            Op::TypeDescLoad(_) => "TypeDescLoad",
         }
     }
 }

--- a/src/vm/verifier.rs
+++ b/src/vm/verifier.rs
@@ -491,6 +491,9 @@ impl Verifier {
 
             // Indirect call
             Op::CallIndirect(argc) => (argc + 1, 1), // pops callable ref + argc args, pushes result
+
+            // Type Descriptor
+            Op::TypeDescLoad(_) => (0, 1), // pushes type descriptor ref
         }
     }
 }

--- a/std/prelude.mc
+++ b/std/prelude.mc
@@ -1817,16 +1817,6 @@ fun sort_float(v: Vec<float>) {
 //   slot 2: field_count (int, 0 for primitives)
 //   slot 3+: field_names (strings)
 
-// Box a value with type info into a dyn value.
-// type_info: reference to a type_info heap object (created by codegen)
-// value: the value to box
-fun __dyn_box(type_info: any, value: any) -> any {
-    let obj = __alloc_heap(2);
-    __heap_store(obj, 0, type_info);
-    __heap_store(obj, 1, value);
-    return obj;
-}
-
 // Get the type name of a dyn value.
 fun __dyn_type_name(d: dyn) -> string {
     let type_info = __heap_load(d, 0);


### PR DESCRIPTION
## Summary
- 型ディスクリプタをコンパイル時に型テーブルへ収集し、VM起動時にヒープへ事前確保することで `as dyn` の毎回のヒープ確保を廃止
- `match dyn` の型判定を HeapLoad 2回 + I64Eq から HeapLoad 1回 + RefEq（参照同一性比較）に変更
- `__dyn_box` 関数を廃止し、codegen でのインライン化に置き換え

### 変更内容
- `TypeDescriptor` 構造体 + `Chunk.type_descriptors` フィールド追加
- `TypeDescLoad(usize)` オペコード追加（Op/MicroOp 両対応）
- VM 初期化時の型ディスクリプタ事前確保 + GC ルート登録
- `values_equal` に参照同一性ショートカット追加
- バイトコードのシリアライズ/デシリアライズ対応

Closes #184

## Test plan
- [x] `cargo test` 全テスト通過（18 snapshot tests + unit tests）
- [x] `cargo clippy` lint 通過
- [x] `dyn_basic.mc` スナップショットテストで match dyn / as dyn / リフレクション関数の正常動作を確認

🤖 Generated with [Claude Code](https://claude.ai/code)