### PR TITLE
refactor(vm): ObjectKind を廃止しヒープヘッダーを簡素化

### DIFF
--- a/src/compiler/resolver.rs
+++ b/src/compiler/resolver.rs
@@ -156,6 +156,8 @@ pub enum ResolvedExpr {
         op: BinaryOp,
         left: Box<ResolvedExpr>,
         right: Box<ResolvedExpr>,
+        /// Type of the left operand (from typechecker, for codegen to emit type-specific ops)
+        operand_type: Option<Type>,
     },
     Call {
         func_index: usize,
@@ -1509,12 +1511,14 @@ impl<'a> Resolver<'a> {
             Expr::Binary {
                 op, left, right, ..
             } => {
+                let operand_type = left.inferred_type().cloned();
                 let left = self.resolve_expr(*left, scope)?;
                 let right = self.resolve_expr(*right, scope)?;
                 Ok(ResolvedExpr::Binary {
                     op,
                     left: Box::new(left),
                     right: Box::new(right),
+                    operand_type,
                 })
             }
             Expr::Call {

--- a/src/jit/marshal.rs
+++ b/src/jit/marshal.rs
@@ -197,9 +197,6 @@ pub struct JitCallContext {
     pub float_to_string_helper: unsafe extern "C" fn(*mut JitCallContext, u64, u64) -> JitReturn,
     /// HeapAllocDynSimple helper: (ctx, size) -> JitReturn (returns Ref)
     pub heap_alloc_dyn_simple_helper: unsafe extern "C" fn(*mut JitCallContext, u64) -> JitReturn,
-    /// HeapAllocTyped helper: (ctx, data_ref_payload, len_payload, kind) -> JitReturn (returns Ref)
-    pub heap_alloc_typed_helper:
-        unsafe extern "C" fn(*mut JitCallContext, u64, u64, u64) -> JitReturn,
     /// Pointer to JIT function table for direct call dispatch.
     /// Layout: [entry_0, total_regs_0, entry_1, total_regs_1, ...] (u64 pairs).
     /// entry == 0 means the function is not yet JIT-compiled.

--- a/src/vm/microop.rs
+++ b/src/vm/microop.rs
@@ -407,6 +407,12 @@ pub enum MicroOp {
         dst: VReg,
         src: VReg,
     },
+    /// dst = (a == b) as string content equality (follows [ptr, len] layout)
+    StringEq {
+        dst: VReg,
+        a: VReg,
+        b: VReg,
+    },
     /// dst = null ref
     RefNull {
         dst: VReg,
@@ -461,21 +467,19 @@ pub enum MicroOp {
     // ========================================
     // Heap allocation operations
     // ========================================
-    /// Allocate a heap object with `size` null-initialized slots.
+    /// Allocate a heap object with statically-known `size` slots.
+    /// Pops `size` values from the operand stack (or uses `args` vregs) to initialize slots.
+    /// dst = Ref to newly allocated object.
+    HeapAlloc {
+        dst: VReg,
+        args: Vec<VReg>,
+    },
+    /// Allocate a heap object with dynamically-known `size` null-initialized slots.
     /// dst = Ref to newly allocated object.
     HeapAllocDynSimple {
         dst: VReg,
         size: VReg,
     },
-    /// Allocate a typed 2-slot object: [data_ref, len] with specified ObjectKind.
-    /// kind: 0=Slots, 1=String, 2=Array.
-    HeapAllocTyped {
-        dst: VReg,
-        data_ref: VReg,
-        len: VReg,
-        kind: u8,
-    },
-
     // ========================================
     // String operations
     // ========================================

--- a/src/vm/ops.rs
+++ b/src/vm/ops.rs
@@ -122,6 +122,9 @@ pub enum Op {
     // ========================================
     RefEq,
     RefIsNull,
+    /// String content equality: pops two string refs (or null), pushes i32 bool.
+    /// Follows [ptr, len] layout to compare character data.
+    StringEq,
 
     // ========================================
     // Type Conversion
@@ -154,9 +157,6 @@ pub enum Op {
     // Heap Operations
     // ========================================
     HeapAlloc(usize),
-    /// Like HeapAlloc but marks the object with a specific ObjectKind.
-    /// Second parameter is the kind: 0=Slots, 1=String, 2=Array.
-    HeapAllocArray(usize, u8),
     HeapAllocDyn,
     HeapAllocDynSimple,
     HeapLoad(usize),
@@ -176,7 +176,6 @@ pub enum Op {
     Syscall(usize, usize),
     GcHint(usize),
     ValueToString,
-    TypeOf,
     FloatToString,
     ParseInt,
     UMul128Hi,
@@ -291,6 +290,7 @@ impl Op {
             Op::F64Ge => "F64Ge",
             Op::RefEq => "RefEq",
             Op::RefIsNull => "RefIsNull",
+            Op::StringEq => "StringEq",
             Op::I32WrapI64 => "I32WrapI64",
             Op::I64ExtendI32S => "I64ExtendI32S",
             Op::I64ExtendI32U => "I64ExtendI32U",
@@ -311,7 +311,6 @@ impl Op {
             Op::Call(_, _) => "Call",
             Op::Ret => "Ret",
             Op::HeapAlloc(_) => "HeapAlloc",
-            Op::HeapAllocArray(_, _) => "HeapAllocArray",
             Op::HeapAllocDyn => "HeapAllocDyn",
             Op::HeapAllocDynSimple => "HeapAllocDynSimple",
             Op::HeapLoad(_) => "HeapLoad",
@@ -324,7 +323,6 @@ impl Op {
             Op::Syscall(_, _) => "Syscall",
             Op::GcHint(_) => "GcHint",
             Op::ValueToString => "ValueToString",
-            Op::TypeOf => "TypeOf",
             Op::FloatToString => "FloatToString",
             Op::ParseInt => "ParseInt",
             Op::UMul128Hi => "UMul128Hi",

--- a/src/vm/stackmap.rs
+++ b/src/vm/stackmap.rs
@@ -173,7 +173,7 @@ pub fn is_safepoint(op: &super::ops::Op, pc: usize) -> bool {
         Op::Call(_, _) => true,
 
         // Heap allocation is also a safepoint
-        Op::HeapAlloc(_) | Op::HeapAllocArray(_, _) => true,
+        Op::HeapAlloc(_) => true,
 
         // Backward jumps are safepoints
         Op::Jmp(target) => *target < pc,

--- a/src/vm/verifier.rs
+++ b/src/vm/verifier.rs
@@ -454,22 +454,21 @@ impl Verifier {
             Op::Ret => (1, 0),               // pops return value
 
             // Heap operations
-            Op::HeapAlloc(n) => (*n, 1), // pops n slots, pushes ref
-            Op::HeapAllocArray(n, _) => (*n, 1), // pops n slots, pushes ref
-            Op::HeapAllocDyn => (1, 1),  // pops size + size values, pushes ref (simplified)
+            Op::HeapAlloc(n) => (*n, 1),      // pops n slots, pushes ref
+            Op::HeapAllocDyn => (1, 1),       // pops size + size values, pushes ref (simplified)
             Op::HeapAllocDynSimple => (1, 1), // pops size, pushes ref (null-initialized)
-            Op::HeapLoad(_) => (1, 1),   // pops ref, pushes value
-            Op::HeapStore(_) => (2, 0),  // pops ref and value
-            Op::HeapLoadDyn => (2, 1),   // pops ref and index, pushes value
-            Op::HeapStoreDyn => (3, 0),  // pops ref, index, and value
-            Op::HeapLoad2 => (2, 1),     // pops ref and index, pushes value (indirect via slot 0)
-            Op::HeapStore2 => (3, 0),    // pops ref, index, and value (indirect via slot 0)
+            Op::HeapLoad(_) => (1, 1),        // pops ref, pushes value
+            Op::HeapStore(_) => (2, 0),       // pops ref and value
+            Op::HeapLoadDyn => (2, 1),        // pops ref and index, pushes value
+            Op::HeapStoreDyn => (3, 0),       // pops ref, index, and value
+            Op::HeapLoad2 => (2, 1), // pops ref and index, pushes value (indirect via slot 0)
+            Op::HeapStore2 => (3, 0), // pops ref, index, and value (indirect via slot 0)
             Op::HeapOffsetRef => (2, 1), // pops ref and offset, pushes offset ref
             // System / Builtins
             Op::Syscall(_, argc) => (*argc, 1), // pops argc args, pushes result
             Op::GcHint(_) => (0, 0),
             Op::ValueToString => (1, 1), // pops value, pushes string
-            Op::TypeOf => (1, 1),        // pops value, pushes type string
+            Op::StringEq => (2, 1),      // pops two refs, pushes bool
             Op::FloatToString => (1, 1), // pops value, pushes string
             Op::ParseInt => (1, 1),      // pops string, pushes int
             // Exception handling

--- a/tests/snapshots/basic/builtin_functions.mc
+++ b/tests/snapshots/basic/builtin_functions.mc
@@ -1,11 +1,3 @@
-// type_of
-print(type_of(42));
-print(type_of(3.14));
-print(type_of(true));
-print(type_of(nil));
-print(type_of("hello"));
-print(type_of([1, 2, 3]));
-
 // to_string
 print(42.to_string());
 print(3.14.to_string());

--- a/tests/snapshots/basic/builtin_functions.stdout
+++ b/tests/snapshots/basic/builtin_functions.stdout
@@ -1,9 +1,3 @@
-int
-float
-bool
-nil
-string
-array
 42
 3.14
 true


### PR DESCRIPTION
## Summary
- **StringEq opcode** を追加し、文字列の内容比較を専用命令化（ObjectKind なしで動作）
- **TypeOf opcode** を廃止（ObjectKind に依存していたため不要に）
- **HeapAllocArray** を **HeapAlloc** に統合（kind 引数を除去）
- **ObjectKind enum** をヒープヘッダーから完全削除（2ビット解放、reserved 28→30 bits）
- **HeapAlloc MicroOp** を新規追加し、JIT コンパイル対応（alloc + HeapStore の組み合わせで実装）
- **value_to_string** を構造ベースのヒューリスティックに変更（文字の印刷可能性で判定）
- **values_equal** の Ref 比較を参照同一性に変更（文字列比較は StringEq で処理）

Closes #162

## Test plan
- [x] `cargo fmt` — パス
- [x] `cargo check` — パス
- [x] `cargo test` — 全344テストパス（snapshot_basic, snapshot_jit, snapshot_performance 含む）
- [x] `cargo clippy` — 警告なし

🤖 Generated with [Claude Code](https://claude.ai/code)