### PR TITLE
refactor: StringEq opcode を廃止し prelude の _string_eq に統一

### DIFF
--- a/src/compiler/codegen.rs
+++ b/src/compiler/codegen.rs
@@ -879,7 +879,7 @@ impl Codegen {
                 op,
                 left,
                 right,
-                operand_type,
+                operand_type: _,
             } => {
                 // Handle short-circuit evaluation for && and ||
                 // BrIfFalse/BrIf pop the condition value, so we need to Dup first
@@ -975,11 +975,7 @@ impl Codegen {
                         ValueType::I32 => ops.push(Op::I32Eq),
                         ValueType::F32 => ops.push(Op::F32Eq),
                         ValueType::Ref => {
-                            if *operand_type == Some(Type::String) {
-                                ops.push(Op::StringEq);
-                            } else {
-                                ops.push(Op::RefEq);
-                            }
+                            ops.push(Op::RefEq);
                         }
                     },
                     BinaryOp::Ne => match self.infer_expr_type(left) {
@@ -988,11 +984,7 @@ impl Codegen {
                         ValueType::I32 => ops.push(Op::I32Ne),
                         ValueType::F32 => ops.push(Op::F32Ne),
                         ValueType::Ref => {
-                            if *operand_type == Some(Type::String) {
-                                ops.push(Op::StringEq);
-                            } else {
-                                ops.push(Op::RefEq);
-                            }
+                            ops.push(Op::RefEq);
                             ops.push(Op::I32Eqz);
                         }
                     },
@@ -1599,7 +1591,6 @@ impl Codegen {
             // ========================
             "RefEq" => Ok(Op::RefEq),
             "RefIsNull" => Ok(Op::RefIsNull),
-            "StringEq" => Ok(Op::StringEq),
 
             // ========================
             // Type Conversion

--- a/src/compiler/dump.rs
+++ b/src/compiler/dump.rs
@@ -1811,7 +1811,6 @@ impl<'a> Disassembler<'a> {
             Op::Syscall(num, argc) => self.output.push_str(&format!("Syscall {} {}", num, argc)),
             Op::GcHint(size) => self.output.push_str(&format!("GcHint {}", size)),
             Op::ValueToString => self.output.push_str("ValueToString"),
-            Op::StringEq => self.output.push_str("StringEq"),
             Op::FloatToString => self.output.push_str("ToString"),
             Op::ParseInt => self.output.push_str("ParseInt"),
             Op::UMul128Hi => self.output.push_str("UMul128Hi"),
@@ -2261,12 +2260,6 @@ fn format_single_microop(output: &mut String, mop: &MicroOp, chunk: &Chunk) {
         // Ref operations
         MicroOp::RefEq { dst, a, b } => output.push_str(&format!(
             "RefEq {}, {}, {}",
-            format_vreg(dst),
-            format_vreg(a),
-            format_vreg(b)
-        )),
-        MicroOp::StringEq { dst, a, b } => output.push_str(&format!(
-            "StringEq {}, {}, {}",
             format_vreg(dst),
             format_vreg(a),
             format_vreg(b)

--- a/src/jit/compiler_microop.rs
+++ b/src/jit/compiler_microop.rs
@@ -364,7 +364,6 @@ impl MicroOpJitCompiler {
                 | MicroOp::I32TruncF64S { dst, .. }
                 | MicroOp::I64TruncF32S { dst, .. }
                 | MicroOp::RefEq { dst, .. }
-                | MicroOp::StringEq { dst, .. }
                 | MicroOp::RefIsNull { dst, .. }
                 | MicroOp::F64ReinterpretAsI64 { dst, .. } => {
                     record(&mut vreg_tags, dst.0, value_tags::TAG_INT);
@@ -561,7 +560,6 @@ impl MicroOpJitCompiler {
 
             // Ref ops
             MicroOp::RefEq { dst, a, b } => self.emit_ref_eq(dst, a, b),
-            MicroOp::StringEq { .. } => return false, // Too complex for JIT, bail to interpreter
             MicroOp::RefIsNull { dst, src } => self.emit_ref_is_null(dst, src),
             MicroOp::RefNull { dst } => self.emit_ref_null(dst),
 

--- a/src/jit/compiler_microop_x86_64.rs
+++ b/src/jit/compiler_microop_x86_64.rs
@@ -136,7 +136,6 @@ impl MicroOpJitCompiler {
                 | MicroOp::EqzI32 { dst, .. }
                 | MicroOp::CmpI32 { dst, .. }
                 | MicroOp::RefEq { dst, .. }
-                | MicroOp::StringEq { dst, .. }
                 | MicroOp::RefIsNull { dst, .. }
                 | MicroOp::F64ReinterpretAsI64 { dst, .. }
                 | MicroOp::I32WrapI64 { dst, .. }
@@ -588,7 +587,6 @@ impl MicroOpJitCompiler {
 
             // Ref ops
             MicroOp::RefEq { dst, a, b } => self.emit_ref_eq(dst, a, b),
-            MicroOp::StringEq { .. } => Err("StringEq not supported in JIT".to_string()),
             MicroOp::RefIsNull { dst, src } => self.emit_ref_is_null(dst, src),
             MicroOp::RefNull { dst } => self.emit_ref_null(dst),
 

--- a/src/vm/bytecode.rs
+++ b/src/vm/bytecode.rs
@@ -561,7 +561,7 @@ fn write_op<W: Write>(w: &mut W, op: &Op) -> io::Result<()> {
         // Ref Comparison
         Op::RefEq => w.write_all(&[OP_REF_EQ])?,
         Op::RefIsNull => w.write_all(&[OP_REF_IS_NULL])?,
-        Op::StringEq => w.write_all(&[OP_STRING_EQ])?,
+        // OP_STRING_EQ (120) is retired — StringEq is now handled by _string_eq in prelude
 
         // Type Conversion
         Op::I32WrapI64 => w.write_all(&[OP_I32_WRAP_I64])?,
@@ -764,7 +764,7 @@ fn read_op<R: Read>(r: &mut R) -> Result<Op, BytecodeError> {
         // Ref Comparison
         OP_REF_EQ => Op::RefEq,
         OP_REF_IS_NULL => Op::RefIsNull,
-        OP_STRING_EQ => Op::StringEq,
+        // OP_STRING_EQ (120) is retired
 
         // Type Conversion
         OP_I32_WRAP_I64 => Op::I32WrapI64,

--- a/src/vm/microop.rs
+++ b/src/vm/microop.rs
@@ -407,12 +407,6 @@ pub enum MicroOp {
         dst: VReg,
         src: VReg,
     },
-    /// dst = (a == b) as string content equality (follows [ptr, len] layout)
-    StringEq {
-        dst: VReg,
-        a: VReg,
-        b: VReg,
-    },
     /// dst = null ref
     RefNull {
         dst: VReg,

--- a/src/vm/microop_converter.rs
+++ b/src/vm/microop_converter.rs
@@ -1170,17 +1170,6 @@ pub fn convert(func: &Function) -> ConvertedFunction {
                     |dst, a, b| MicroOp::RefEq { dst, a, b },
                 );
             }
-            Op::StringEq => {
-                emit_binop(
-                    &mut vstack,
-                    &mut micro_ops,
-                    &mut next_temp,
-                    &mut max_temp,
-                    &mut vreg_types,
-                    ValueType::I64,
-                    |dst, a, b| MicroOp::StringEq { dst, a, b },
-                );
-            }
             Op::RefIsNull => {
                 let src = pop_vreg(
                     &mut vstack,
@@ -2085,7 +2074,6 @@ fn try_patch_dst(mop: &mut MicroOp, new_dst: VReg) -> Option<VReg> {
         | MicroOp::CmpF32 { dst, .. }
         // Ref binary
         | MicroOp::RefEq { dst, .. }
-        | MicroOp::StringEq { dst, .. }
         // Unary ops
         | MicroOp::NegI64 { dst, .. }
         | MicroOp::NegF64 { dst, .. }

--- a/src/vm/ops.rs
+++ b/src/vm/ops.rs
@@ -122,9 +122,6 @@ pub enum Op {
     // ========================================
     RefEq,
     RefIsNull,
-    /// String content equality: pops two string refs (or null), pushes i32 bool.
-    /// Follows [ptr, len] layout to compare character data.
-    StringEq,
 
     // ========================================
     // Type Conversion
@@ -290,7 +287,6 @@ impl Op {
             Op::F64Ge => "F64Ge",
             Op::RefEq => "RefEq",
             Op::RefIsNull => "RefIsNull",
-            Op::StringEq => "StringEq",
             Op::I32WrapI64 => "I32WrapI64",
             Op::I64ExtendI32S => "I64ExtendI32S",
             Op::I64ExtendI32U => "I64ExtendI32U",

--- a/src/vm/verifier.rs
+++ b/src/vm/verifier.rs
@@ -468,7 +468,6 @@ impl Verifier {
             Op::Syscall(_, argc) => (*argc, 1), // pops argc args, pushes result
             Op::GcHint(_) => (0, 0),
             Op::ValueToString => (1, 1), // pops value, pushes string
-            Op::StringEq => (2, 1),      // pops two refs, pushes bool
             Op::FloatToString => (1, 1), // pops value, pushes string
             Op::ParseInt => (1, 1),      // pops string, pushes int
             // Exception handling


### PR DESCRIPTION
## Summary

- `Op::StringEq` / `MicroOp::StringEq` opcode およびVM・JIT の関連ハンドラを削除
- desugar フェーズで既に文字列比較を `_string_eq()` 関数呼び出しに変換していたため、opcode は不要だった
- `strings_equal()` VM メソッドを削除
- codegen の `operand_type` による StringEq 分岐を削除（RefEq に統一）

## Test plan

- [x] cargo check
- [x] cargo test（326 unit + 18 snapshot 全パス）
- [x] cargo clippy

Closes #189

🤖 Generated with [Claude Code](https://claude.ai/code)