### PR TITLE
refactor: FloatToString opcode を廃止し prelude の _float_to_string に統一

### DIFF
--- a/src/compiler/codegen.rs
+++ b/src/compiler/codegen.rs
@@ -167,8 +167,8 @@ impl Codegen {
             ResolvedExpr::SpawnFunc { .. } => ValueType::I64,
             ResolvedExpr::Builtin { name, .. } => match name.as_str() {
                 "len" | "argc" | "parse_int" | "__umul128_hi" => ValueType::I64,
-                "__float_to_string" | "channel" | "recv" | "argv" | "args" | "__alloc_heap"
-                | "__alloc_string" | "__null_ptr" | "__ptr_offset" => ValueType::Ref,
+                "channel" | "recv" | "argv" | "args" | "__alloc_heap" | "__alloc_string"
+                | "__null_ptr" | "__ptr_offset" => ValueType::Ref,
                 "__heap_load" => ValueType::I64, // Returns raw slot value; type unknown at compile time
                 "__value_to_string" => ValueType::Ref, // returns string
                 "send" | "join" | "print" | "__heap_store" => ValueType::Ref, // returns null
@@ -1119,13 +1119,6 @@ impl Codegen {
                         // Both Array<T> and String have [ptr, len] layout
                         ops.push(Op::HeapLoad(1));
                     }
-                    "__float_to_string" => {
-                        if args.len() != 1 {
-                            return Err("__float_to_string takes exactly 1 argument".to_string());
-                        }
-                        self.compile_expr(&args[0], ops)?;
-                        ops.push(Op::FloatToString);
-                    }
                     "parse_int" => {
                         if args.len() != 1 {
                             return Err("parse_int takes exactly 1 argument".to_string());
@@ -1652,7 +1645,6 @@ impl Codegen {
             "HeapStoreDyn" => Ok(Op::HeapStoreDyn),
 
             // Type operations
-            "FloatToString" => Ok(Op::FloatToString),
             "ParseInt" => Ok(Op::ParseInt),
             // Exception handling
             "Throw" => Ok(Op::Throw),

--- a/src/compiler/dump.rs
+++ b/src/compiler/dump.rs
@@ -1811,7 +1811,6 @@ impl<'a> Disassembler<'a> {
             Op::Syscall(num, argc) => self.output.push_str(&format!("Syscall {} {}", num, argc)),
             Op::GcHint(size) => self.output.push_str(&format!("GcHint {}", size)),
             Op::ValueToString => self.output.push_str("ValueToString"),
-            Op::FloatToString => self.output.push_str("ToString"),
             Op::ParseInt => self.output.push_str("ParseInt"),
             Op::UMul128Hi => self.output.push_str("UMul128Hi"),
             // Exception handling
@@ -2366,11 +2365,6 @@ fn format_single_microop(output: &mut String, mop: &MicroOp, chunk: &Chunk) {
                 s
             ))
         }
-        MicroOp::FloatToString { dst, src } => output.push_str(&format!(
-            "ToString {}, {}",
-            format_vreg(dst),
-            format_vreg(src)
-        )),
         MicroOp::ValueToString { dst, src } => output.push_str(&format!(
             "ValueToString {}, {}",
             format_vreg(dst),

--- a/src/compiler/resolver.rs
+++ b/src/compiler/resolver.rs
@@ -317,7 +317,6 @@ impl<'a> Resolver<'a> {
                 "__value_to_string".to_string(),
                 "len".to_string(),
                 "type_of".to_string(),
-                "__float_to_string".to_string(),
                 "parse_int".to_string(),
                 // Thread operations
                 "spawn".to_string(),

--- a/src/compiler/typechecker.rs
+++ b/src/compiler/typechecker.rs
@@ -2924,16 +2924,6 @@ impl TypeChecker {
                 }
                 Some(Type::String)
             }
-            "__float_to_string" => {
-                if args.len() != 1 {
-                    self.errors
-                        .push(TypeError::new("__float_to_string expects 1 argument", span));
-                }
-                for arg in args {
-                    self.infer_expr(arg, env);
-                }
-                Some(Type::String)
-            }
             "parse_int" => {
                 if args.len() != 1 {
                     self.errors

--- a/src/jit/marshal.rs
+++ b/src/jit/marshal.rs
@@ -193,8 +193,6 @@ pub struct JitCallContext {
     pub string_cache: *const u64,
     /// Number of entries in the string cache
     pub string_cache_len: u64,
-    /// FloatToString helper: (ctx, tag, payload) -> JitReturn (returns Ref to string)
-    pub float_to_string_helper: unsafe extern "C" fn(*mut JitCallContext, u64, u64) -> JitReturn,
     /// HeapAllocDynSimple helper: (ctx, size) -> JitReturn (returns Ref)
     pub heap_alloc_dyn_simple_helper: unsafe extern "C" fn(*mut JitCallContext, u64) -> JitReturn,
     /// Pointer to JIT function table for direct call dispatch.

--- a/src/vm/bytecode.rs
+++ b/src/vm/bytecode.rs
@@ -402,7 +402,7 @@ const OP_SYSCALL: u8 = 86;
 const OP_GC_HINT: u8 = 87;
 const OP_VALUE_TO_STRING: u8 = 88;
 const OP_TYPE_OF: u8 = 89;
-const OP_FLOAT_TO_STRING: u8 = 90;
+const _OP_FLOAT_TO_STRING: u8 = 90; // retired
 const OP_PARSE_INT: u8 = 91;
 // Exception Handling
 const OP_THROW: u8 = 93;
@@ -442,7 +442,7 @@ const OP_F64_REINTERPRET_AS_I64: u8 = 116;
 const OP_UMUL128_HI: u8 = 117;
 const OP_HEAP_OFFSET_REF: u8 = 118;
 const OP_TYPE_DESC_LOAD: u8 = 119;
-const OP_STRING_EQ: u8 = 120;
+const _OP_STRING_EQ: u8 = 120; // retired
 
 fn write_op<W: Write>(w: &mut W, op: &Op) -> io::Result<()> {
     match op {
@@ -630,7 +630,7 @@ fn write_op<W: Write>(w: &mut W, op: &Op) -> io::Result<()> {
             write_u32(w, *size as u32)?;
         }
         Op::ValueToString => w.write_all(&[OP_VALUE_TO_STRING])?,
-        Op::FloatToString => w.write_all(&[OP_FLOAT_TO_STRING])?,
+        // OP_FLOAT_TO_STRING (90) is retired — now handled by _float_to_string in prelude
         Op::ParseInt => w.write_all(&[OP_PARSE_INT])?,
         // Exception Handling
         Op::Throw => w.write_all(&[OP_THROW])?,
@@ -809,7 +809,7 @@ fn read_op<R: Read>(r: &mut R) -> Result<Op, BytecodeError> {
         OP_SYSCALL => Op::Syscall(read_u32(r)? as usize, read_u32(r)? as usize),
         OP_GC_HINT => Op::GcHint(read_u32(r)? as usize),
         OP_VALUE_TO_STRING => Op::ValueToString,
-        OP_FLOAT_TO_STRING => Op::FloatToString,
+        // OP_FLOAT_TO_STRING (90) is retired
         OP_PARSE_INT => Op::ParseInt,
         // Exception Handling
         OP_THROW => Op::Throw,
@@ -1242,7 +1242,6 @@ mod tests {
             Op::Syscall(7, 2),
             Op::GcHint(1024),
             Op::ValueToString,
-            Op::FloatToString,
             Op::ParseInt,
             // Exception Handling
             Op::Throw,

--- a/src/vm/microop.rs
+++ b/src/vm/microop.rs
@@ -489,12 +489,6 @@ pub enum MicroOp {
         dst: VReg,
         idx: usize,
     },
-    /// Convert value to string representation.
-    /// dst = to_string(src) (Ref to newly allocated heap string)
-    FloatToString {
-        dst: VReg,
-        src: VReg,
-    },
     /// Convert any value to its string representation.
     /// dst = to_string(src) (Ref to newly allocated heap string)
     ValueToString {

--- a/src/vm/microop_converter.rs
+++ b/src/vm/microop_converter.rs
@@ -1675,23 +1675,6 @@ pub fn convert(func: &Function) -> ConvertedFunction {
                 micro_ops.push(MicroOp::TypeDescLoad { dst, idx: *idx });
                 vstack.push(Vse::RegRef(dst));
             }
-            Op::FloatToString => {
-                let src = pop_vreg(
-                    &mut vstack,
-                    &mut micro_ops,
-                    &mut next_temp,
-                    &mut max_temp,
-                    &mut vreg_types,
-                );
-                let dst = alloc_temp(
-                    &mut next_temp,
-                    &mut max_temp,
-                    &mut vreg_types,
-                    ValueType::Ref,
-                );
-                micro_ops.push(MicroOp::FloatToString { dst, src });
-                vstack.push(Vse::RegRef(dst));
-            }
             Op::UMul128Hi => {
                 let b = pop_vreg(
                     &mut vstack,

--- a/src/vm/ops.rs
+++ b/src/vm/ops.rs
@@ -173,7 +173,6 @@ pub enum Op {
     Syscall(usize, usize),
     GcHint(usize),
     ValueToString,
-    FloatToString,
     ParseInt,
     UMul128Hi,
 
@@ -319,7 +318,6 @@ impl Op {
             Op::Syscall(_, _) => "Syscall",
             Op::GcHint(_) => "GcHint",
             Op::ValueToString => "ValueToString",
-            Op::FloatToString => "FloatToString",
             Op::ParseInt => "ParseInt",
             Op::UMul128Hi => "UMul128Hi",
             Op::Throw => "Throw",

--- a/src/vm/verifier.rs
+++ b/src/vm/verifier.rs
@@ -468,7 +468,6 @@ impl Verifier {
             Op::Syscall(_, argc) => (*argc, 1), // pops argc args, pushes result
             Op::GcHint(_) => (0, 0),
             Op::ValueToString => (1, 1), // pops value, pushes string
-            Op::FloatToString => (1, 1), // pops value, pushes string
             Op::ParseInt => (1, 1),      // pops string, pushes int
             // Exception handling
             Op::Throw => (1, 0),


### PR DESCRIPTION
## Summary

- `Op::FloatToString` / `MicroOp::FloatToString` opcode を削除
- `__float_to_string` ビルトインを resolver / typechecker / codegen から削除
- JIT の `float_to_string_helper` およびマーシャリングフィールドを削除
- JitCallContext フィールド削減に伴うオフセット更新:
  - `heap_alloc_dyn_simple_helper`: 80 → 72
  - `jit_function_table`: 88 → 80
- prelude.mc の `_float_to_string` は `__float_to_string` を使わず独自実装済みのためそのまま利用

13 files, -172 lines

## Test plan

- [x] cargo check
- [x] cargo test（326 unit + 18 snapshot 全パス）
- [x] cargo clippy

Part of #190

🤖 Generated with [Claude Code](https://claude.ai/code)