### PR TITLE
fix(map): Map.get の戻り値型を V? に変更 (#195)

### DIFF
--- a/std/prelude.mc
+++ b/std/prelude.mc
@@ -1438,21 +1438,21 @@ impl<K, V> Map<K, V> {
     }
 
     // Get a value from the map by int key
-    // Returns 0 if key not found
-    fun get_int(self, key: int) -> V {
+    // Returns nil if key not found
+    fun get_int(self, key: int) -> V? {
         let entry_ptr = self._find_entry_int(key);
         if entry_ptr == 0 {
-            return 0;
+            return nil;
         }
         return __heap_load(entry_ptr, 1);
     }
 
     // Get a value from the map by string key
-    // Returns 0 if key not found
-    fun get_string(self, key: string) -> V {
+    // Returns nil if key not found
+    fun get_string(self, key: string) -> V? {
         let entry_ptr = self._find_entry_string(key);
         if entry_ptr == 0 {
-            return 0;
+            return nil;
         }
         return __heap_load(entry_ptr, 1);
     }

--- a/tests/snapshots/basic/map_basic.mc
+++ b/tests/snapshots/basic/map_basic.mc
@@ -31,7 +31,5 @@ if removed {
 }
 print(m.len());
 
-// Test get non-existent key returns 0
-// Note: map.get returns type-unsafe default (int 0) for missing keys,
-// so print_debug (runtime dispatch) is needed here. See #195.
-print_debug(m.get("city"));
+// Test get non-existent key returns nil
+print(m.get("city"));

--- a/tests/snapshots/basic/map_basic.stdout
+++ b/tests/snapshots/basic/map_basic.stdout
@@ -7,4 +7,4 @@ Bob
 2
 removed city
 1
-0
+nil


### PR DESCRIPTION
## Summary
- `Map.get_int` / `Map.get_string` の戻り値型を `V` → `V?` に変更
- キーが存在しない場合に型不安全な `0` ではなく `nil` を返すように修正
- テスト (`map_basic.mc`) を nullable 対応に更新

Closes #195

## Test plan
- [x] `cargo fmt / check / test / clippy` 全パス
- [x] `map_basic.mc` でキー不在時に `nil` が出力されることを確認
- [x] 既存の Map テスト（map_collision, map_int_keys, map_resize 等）が影響なく通過

🤖 Generated with [Claude Code](https://claude.ai/code)