### PR TITLE
refactor: as dyn + match dyn で ValueToString のプリミティブ型ディスパッチを実装

### DIFF
--- a/src/compiler/codegen.rs
+++ b/src/compiler/codegen.rs
@@ -166,7 +166,7 @@ impl Codegen {
             ResolvedExpr::AssociatedFunctionCall { .. } => ValueType::Ref,
             ResolvedExpr::SpawnFunc { .. } => ValueType::I64,
             ResolvedExpr::Builtin { name, .. } => match name.as_str() {
-                "len" | "argc" | "parse_int" | "__umul128_hi" | "__value_tag" => ValueType::I64,
+                "len" | "argc" | "parse_int" | "__umul128_hi" => ValueType::I64,
                 "channel" | "recv" | "argv" | "args" | "__alloc_heap" | "__alloc_string"
                 | "__null_ptr" | "__ptr_offset" => ValueType::Ref,
                 "__heap_load" => ValueType::I64, // Returns raw slot value; type unknown at compile time
@@ -1098,13 +1098,6 @@ impl Codegen {
                         }
                         self.compile_expr(&args[0], ops)?;
                         ops.push(Op::ValueToString);
-                    }
-                    "__value_tag" => {
-                        if args.len() != 1 {
-                            return Err("__value_tag takes exactly 1 argument".to_string());
-                        }
-                        self.compile_expr(&args[0], ops)?;
-                        ops.push(Op::ValueTag);
                     }
                     "__syscall" => {
                         // __syscall(num, ...args) -> result

--- a/src/compiler/desugar.rs
+++ b/src/compiler/desugar.rs
@@ -671,7 +671,7 @@ impl Desugar {
                     }
 
                     // For all other types (any, nullable, array, vec, map, etc.):
-                    // use _value_to_string (prelude function with runtime type dispatch)
+                    // use _value_to_string(v as dyn) with match dyn dispatch
                     return Expr::Block {
                         statements: vec![Statement::Expr {
                             expr: Expr::Call {
@@ -680,7 +680,11 @@ impl Desugar {
                                 args: vec![Expr::Call {
                                     callee: "_value_to_string".to_string(),
                                     type_args: vec![],
-                                    args: vec![arg],
+                                    args: vec![Expr::AsDyn {
+                                        expr: Box::new(arg),
+                                        span,
+                                        inferred_type: Some(Type::Dyn),
+                                    }],
                                     span,
                                     inferred_type: Some(Type::String),
                                 }],

--- a/src/compiler/dump.rs
+++ b/src/compiler/dump.rs
@@ -1812,7 +1812,6 @@ impl<'a> Disassembler<'a> {
             Op::Syscall(num, argc) => self.output.push_str(&format!("Syscall {} {}", num, argc)),
             Op::GcHint(size) => self.output.push_str(&format!("GcHint {}", size)),
             Op::ValueToString => self.output.push_str("ValueToString"),
-            Op::ValueTag => self.output.push_str("ValueTag"),
             Op::ParseInt => self.output.push_str("ParseInt"),
             Op::UMul128Hi => self.output.push_str("UMul128Hi"),
             // Exception handling
@@ -2369,11 +2368,6 @@ fn format_single_microop(output: &mut String, mop: &MicroOp, chunk: &Chunk) {
         }
         MicroOp::ValueToString { dst, src } => output.push_str(&format!(
             "ValueToString {}, {}",
-            format_vreg(dst),
-            format_vreg(src)
-        )),
-        MicroOp::ValueTag { dst, src } => output.push_str(&format!(
-            "ValueTag {}, {}",
             format_vreg(dst),
             format_vreg(src)
         )),

--- a/src/compiler/resolver.rs
+++ b/src/compiler/resolver.rs
@@ -316,7 +316,6 @@ impl<'a> Resolver<'a> {
             functions: HashMap::new(),
             builtins: vec![
                 "__value_to_string".to_string(),
-                "__value_tag".to_string(),
                 "len".to_string(),
                 "type_of".to_string(),
                 "parse_int".to_string(),

--- a/src/compiler/typechecker.rs
+++ b/src/compiler/typechecker.rs
@@ -2881,13 +2881,6 @@ impl TypeChecker {
                 }
                 Some(Type::String)
             }
-            "__value_tag" => {
-                // __value_tag accepts any type, returns int (type tag: 0=int, 1=float, 2=bool, 3=nil, 4=ref)
-                for arg in args {
-                    self.infer_expr(arg, env);
-                }
-                Some(Type::Int)
-            }
             "__syscall" => {
                 // __syscall(num, ...args) -> Int | String
                 // First argument must be syscall number (Int), rest depends on syscall

--- a/src/jit/compiler_microop.rs
+++ b/src/jit/compiler_microop.rs
@@ -397,7 +397,6 @@ impl MicroOpJitCompiler {
                 | MicroOp::HeapLoad2 { dst, .. }
                 | MicroOp::StackPop { dst }
                 | MicroOp::ValueToString { dst, .. }
-                | MicroOp::ValueTag { dst, .. }
                 | MicroOp::HeapAlloc { dst, .. }
                 | MicroOp::HeapAllocDynSimple { dst, .. }
                 | MicroOp::StringConst { dst, .. } => {
@@ -571,7 +570,6 @@ impl MicroOpJitCompiler {
             // String operations
             MicroOp::StringConst { dst, idx } => self.emit_string_const(dst, *idx),
             MicroOp::ValueToString { .. } => Err("ValueToString not supported in JIT".to_string()),
-            MicroOp::ValueTag { .. } => Err("ValueTag not supported in JIT".to_string()),
             // Heap allocation operations
             MicroOp::HeapAlloc { dst, args } => self.emit_heap_alloc(dst, args),
             MicroOp::HeapAllocDynSimple { dst, size } => self.emit_heap_alloc_dyn_simple(dst, size),

--- a/src/jit/compiler_microop_x86_64.rs
+++ b/src/jit/compiler_microop_x86_64.rs
@@ -177,7 +177,6 @@ impl MicroOpJitCompiler {
                 | MicroOp::HeapLoad2 { dst, .. }
                 | MicroOp::StackPop { dst }
                 | MicroOp::ValueToString { dst, .. }
-                | MicroOp::ValueTag { dst, .. }
                 | MicroOp::HeapAlloc { dst, .. }
                 | MicroOp::HeapAllocDynSimple { dst, .. }
                 | MicroOp::StringConst { dst, .. } => {
@@ -598,7 +597,6 @@ impl MicroOpJitCompiler {
             // String operations
             MicroOp::StringConst { dst, idx } => self.emit_string_const(dst, *idx),
             MicroOp::ValueToString { .. } => Err("ValueToString not supported in JIT".to_string()),
-            MicroOp::ValueTag { .. } => Err("ValueTag not supported in JIT".to_string()),
             // Heap allocation operations
             MicroOp::HeapAlloc { dst, args } => self.emit_heap_alloc(dst, args),
             MicroOp::HeapAllocDynSimple { dst, size } => self.emit_heap_alloc_dyn_simple(dst, size),

--- a/src/vm/bytecode.rs
+++ b/src/vm/bytecode.rs
@@ -450,7 +450,6 @@ const OP_F64_REINTERPRET_AS_I64: u8 = 116;
 const OP_UMUL128_HI: u8 = 117;
 const OP_HEAP_OFFSET_REF: u8 = 118;
 const OP_TYPE_DESC_LOAD: u8 = 119;
-const OP_VALUE_TAG: u8 = 120;
 
 fn write_op<W: Write>(w: &mut W, op: &Op) -> io::Result<()> {
     match op {
@@ -637,7 +636,6 @@ fn write_op<W: Write>(w: &mut W, op: &Op) -> io::Result<()> {
             write_u32(w, *size as u32)?;
         }
         Op::ValueToString => w.write_all(&[OP_VALUE_TO_STRING])?,
-        Op::ValueTag => w.write_all(&[OP_VALUE_TAG])?,
         Op::ParseInt => w.write_all(&[OP_PARSE_INT])?,
         // Exception Handling
         Op::Throw => w.write_all(&[OP_THROW])?,
@@ -815,7 +813,6 @@ fn read_op<R: Read>(r: &mut R) -> Result<Op, BytecodeError> {
         OP_SYSCALL => Op::Syscall(read_u32(r)? as usize, read_u32(r)? as usize),
         OP_GC_HINT => Op::GcHint(read_u32(r)? as usize),
         OP_VALUE_TO_STRING => Op::ValueToString,
-        OP_VALUE_TAG => Op::ValueTag,
         OP_PARSE_INT => Op::ParseInt,
         // Exception Handling
         OP_THROW => Op::Throw,
@@ -1248,7 +1245,6 @@ mod tests {
             Op::Syscall(7, 2),
             Op::GcHint(1024),
             Op::ValueToString,
-            Op::ValueTag,
             Op::ParseInt,
             // Exception Handling
             Op::Throw,

--- a/src/vm/microop.rs
+++ b/src/vm/microop.rs
@@ -495,12 +495,6 @@ pub enum MicroOp {
         dst: VReg,
         src: VReg,
     },
-    /// Return the runtime type tag of a value.
-    /// dst = value_tag(src) (0=int, 1=float, 2=bool, 3=nil, 4=ref)
-    ValueTag {
-        dst: VReg,
-        src: VReg,
-    },
     // ========================================
     // Stack Bridge (for Raw op interop)
     // ========================================

--- a/src/vm/microop_converter.rs
+++ b/src/vm/microop_converter.rs
@@ -1716,23 +1716,6 @@ pub fn convert(func: &Function) -> ConvertedFunction {
                 micro_ops.push(MicroOp::ValueToString { dst, src });
                 vstack.push(Vse::Reg(dst));
             }
-            Op::ValueTag => {
-                let src = pop_vreg(
-                    &mut vstack,
-                    &mut micro_ops,
-                    &mut next_temp,
-                    &mut max_temp,
-                    &mut vreg_types,
-                );
-                let dst = alloc_temp(
-                    &mut next_temp,
-                    &mut max_temp,
-                    &mut vreg_types,
-                    ValueType::I64,
-                );
-                micro_ops.push(MicroOp::ValueTag { dst, src });
-                vstack.push(Vse::Reg(dst));
-            }
 
             // ============================================================
             // Heap allocation operations

--- a/src/vm/ops.rs
+++ b/src/vm/ops.rs
@@ -173,8 +173,6 @@ pub enum Op {
     Syscall(usize, usize),
     GcHint(usize),
     ValueToString,
-    /// Return the runtime type tag of a value (0=int, 1=float, 2=bool, 3=nil, 4=ref).
-    ValueTag,
     ParseInt,
     UMul128Hi,
 
@@ -320,7 +318,6 @@ impl Op {
             Op::Syscall(_, _) => "Syscall",
             Op::GcHint(_) => "GcHint",
             Op::ValueToString => "ValueToString",
-            Op::ValueTag => "ValueTag",
             Op::ParseInt => "ParseInt",
             Op::UMul128Hi => "UMul128Hi",
             Op::Throw => "Throw",

--- a/src/vm/verifier.rs
+++ b/src/vm/verifier.rs
@@ -468,7 +468,6 @@ impl Verifier {
             Op::Syscall(_, argc) => (*argc, 1), // pops argc args, pushes result
             Op::GcHint(_) => (0, 0),
             Op::ValueToString => (1, 1), // pops value, pushes string
-            Op::ValueTag => (1, 1),      // pops value, pushes type tag int
             Op::ParseInt => (1, 1),      // pops string, pushes int
             // Exception handling
             Op::Throw => (1, 0),

--- a/src/vm/vm.rs
+++ b/src/vm/vm.rs
@@ -1659,18 +1659,6 @@ impl VM {
                     let r = self.heap.alloc_string(s)?;
                     self.stack[sb + dst.0] = Value::Ref(r);
                 }
-                MicroOp::ValueTag { dst, src } => {
-                    let sb = self.frames.last().unwrap().stack_base;
-                    let value = self.stack[sb + src.0];
-                    let tag = match value {
-                        Value::I64(_) => 0i64,
-                        Value::F64(_) => 1,
-                        Value::Bool(_) => 2,
-                        Value::Null => 3,
-                        Value::Ref(_) => 4,
-                    };
-                    self.stack[sb + dst.0] = Value::I64(tag);
-                }
                 MicroOp::HeapAlloc { dst, args } => {
                     let sb = self.frames.last().unwrap().stack_base;
                     let slots: Vec<Value> = args.iter().map(|a| self.stack[sb + a.0]).collect();
@@ -2822,17 +2810,6 @@ impl VM {
                 let s = self.value_to_string(&value)?;
                 let r = self.heap.alloc_string(s)?;
                 self.stack.push(Value::Ref(r));
-            }
-            Op::ValueTag => {
-                let value = self.stack.pop().ok_or("stack underflow")?;
-                let tag = match value {
-                    Value::I64(_) => 0i64,
-                    Value::F64(_) => 1,
-                    Value::Bool(_) => 2,
-                    Value::Null => 3,
-                    Value::Ref(_) => 4,
-                };
-                self.stack.push(Value::I64(tag));
             }
             Op::GcHint(_bytes) => {
                 // Hint about upcoming allocation - might trigger GC

--- a/std/prelude.mc
+++ b/std/prelude.mc
@@ -852,26 +852,26 @@ fun print<T: ToString>(v: T) {
     print_str("\n");
 }
 
-// Convert any value to its string representation (runtime type dispatch).
+// Convert a dyn value to its string representation using match dyn.
 // Dispatches to type-specific moca functions for primitives.
-// Falls back to __value_to_string (VM opcode) for ref types.
-fun _value_to_string(v: any) -> string {
-    let tag = __value_tag(v);
-    if tag == 0 { return _int_to_string(v); }
-    if tag == 1 { return _float_to_string(v); }
-    if tag == 2 { return _bool_to_string(v); }
-    if tag == 3 { return "nil"; }
-    // ref case: use existing VM opcode for now
-    return __value_to_string(v);
+// Falls back to __value_to_string (VM opcode) for unmatched types.
+fun _value_to_string(v: dyn) -> string {
+    match dyn v {
+        x: int => { return _int_to_string(x); }
+        x: float => { return _float_to_string(x); }
+        x: bool => { return _bool_to_string(x); }
+        x: string => { return x; }
+        _ => { return __value_to_string(__heap_load(v, 1)); }
+    }
 }
 
-fun debug(v: any) -> string {
-    return _value_to_string(v);
+fun debug<T>(v: T) -> string {
+    return _value_to_string(v as dyn);
 }
 
 // Print any value to stdout with a trailing newline (runtime type dispatch).
-fun print_debug(v: any) {
-    print_str(_value_to_string(v));
+fun print_debug<T>(v: T) {
+    print_str(_value_to_string(v as dyn));
     print_str("\n");
 }
 


### PR DESCRIPTION
## Summary
- `__value_tag` opcode を廃止し、既存の `as dyn` + `match dyn` 機構でランタイム型ディスパッチを実装
- `_value_to_string(v: dyn)` を `match dyn` でプリミティブ型（int/float/bool/string）を分岐、`_` で `__value_to_string` にフォールバック
- `debug` / `print_debug` をジェネリック関数に変更し、内部で `v as dyn` でボックス化
- desugar の `__print_dyn_fallback` も `_value_to_string(v as dyn)` を生成するように更新
- 新規 opcode 追加なし（既存の TypeDescLoad + RefEq + HeapAlloc で実現）

Closes #198

## Test plan
- [x] `cargo fmt` パス
- [x] `cargo check` パス
- [x] `cargo test` 全テスト通過
- [x] `cargo clippy` 警告なし

🤖 Generated with [Claude Code](https://claude.ai/code)