### PR TITLE
refactor: debug/print_debug を dyn パラメータに変更

### DIFF
--- a/std/prelude.mc
+++ b/std/prelude.mc
@@ -865,13 +865,13 @@ fun _value_to_string(v: dyn) -> string {
     }
 }
 
-fun debug<T>(v: T) -> string {
-    return _value_to_string(v as dyn);
+fun debug(v: dyn) -> string {
+    return _value_to_string(v);
 }
 
 // Print any value to stdout with a trailing newline (runtime type dispatch).
-fun print_debug<T>(v: T) {
-    print_str(_value_to_string(v as dyn));
+fun print_debug(v: dyn) {
+    print_str(_value_to_string(v));
     print_str("\n");
 }
 

--- a/tests/snapshots/basic/io_error.mc
+++ b/tests/snapshots/basic/io_error.mc
@@ -5,10 +5,11 @@ let result1 = write(99, "test", 4);
 print(result1);
 
 // Test 2: Read from invalid fd (should return EBADF = -1)
-// Note: read() returns string but error values are integers (type-unsafe),
-// so print_debug (runtime dispatch) is needed here. See #195.
+// Note: read() returns string but error values are integers (type-unsafe).
+// Use __value_to_string (VM opcode) for type-unsafe runtime dispatch. See #195.
 let result2 = read(99, 100);
-print_debug(result2);
+print_str(__value_to_string(result2));
+print_str("\n");
 
 // Test 3: Close invalid fd (should return EBADF = -1)
 let result3 = close(99);


### PR DESCRIPTION
## Summary
- `debug<T>(v: T)` → `debug(v: dyn)` に変更
- `print_debug<T>(v: T)` → `print_debug(v: dyn)` に変更
- 暗黙的な dyn 変換 (`check_call_args`) により、呼び出し側で自動的に `as dyn` が挿入される
- `io_error.mc` テストの type-unsafe ケースを `__value_to_string` VM opcode に変更

## 発見した問題
調査中に TypeDesc のモノモーフィゼーション関連バグを発見 → #202 として起票

Closes #201

## Test plan
- [x] `cargo fmt` / `cargo check` / `cargo test` / `cargo clippy` all pass
- [x] `print_debug(42)`, `print_debug("hello")` 等の基本的なケースが動作確認済み

🤖 Generated with [Claude Code](https://claude.com/claude-code)