### PR TITLE
fix: TypeDesc mismatch in monomorphized generic as dyn

### DIFF
--- a/tests/snapshots/generics/generic_as_dyn.mc
+++ b/tests/snapshots/generics/generic_as_dyn.mc
@@ -1,0 +1,30 @@
+// Test: TypeDesc from generic as dyn matches correctly in match dyn
+fun box_it<T>(v: T) -> dyn {
+    return v as dyn;
+}
+
+fun type_name_of(v: dyn) -> string {
+    match dyn v {
+        x: int => { return "int"; }
+        x: float => { return "float"; }
+        x: bool => { return "bool"; }
+        x: string => { return "string"; }
+        _ => { return "other"; }
+    }
+}
+
+// Generic boxing should produce TypeDesc that matches in match dyn
+print_str(type_name_of(box_it("hello")));
+print_str("\n");
+print_str(type_name_of(box_it(42)));
+print_str("\n");
+print_str(type_name_of(box_it(true)));
+print_str("\n");
+print_str(type_name_of(box_it(3.14)));
+print_str("\n");
+
+// Direct boxing should also work (regression check)
+print_str(type_name_of("world" as dyn));
+print_str("\n");
+print_str(type_name_of(99 as dyn));
+print_str("\n");

--- a/tests/snapshots/generics/generic_as_dyn.stdout
+++ b/tests/snapshots/generics/generic_as_dyn.stdout
@@ -1,0 +1,6 @@
+string
+int
+bool
+float
+string
+int


### PR DESCRIPTION
## Summary
- モノモーフィゼーション時に `inferred_type` フィールドの `Type::Param` が具象型に置換されていなかったバグを修正
- `substitute_expr` 内で全 Expr の `inferred_type` に `substitute_type_in_type` を適用
- `object_type` フィールド（`Index`, `IndexAssign`）も同様に置換

## 原因
`substitute_expr` が `inferred_type: inferred_type.clone()` としていたため、`box_it<string>` 内の `v as dyn` が `TypeDesc("T")` を生成していた。`match dyn` では `TypeDesc("string")` と比較するため RefEq が失敗し、wildcard arm にフォールスルーしていた。

## テスト
- `generic_as_dyn.mc`: ジェネリック関数経由の `as dyn` が `match dyn` で正しくマッチすることを確認

Closes #202

## Test plan
- [x] `cargo fmt` / `cargo check` / `cargo test` / `cargo clippy` all pass
- [x] 新規テスト `generic_as_dyn.mc` が string/int/bool/float すべて正しくマッチ

🤖 Generated with [Claude Code](https://claude.com/claude-code)