### PR TITLE
feat: TypeDescriptor aux_type_tags でネスト型の再帰 debug 表示

### DIFF
--- a/src/vm/bytecode.rs
+++ b/src/vm/bytecode.rs
@@ -107,6 +107,10 @@ pub fn write_chunk<W: Write>(w: &mut W, chunk: &Chunk) -> io::Result<()> {
         for field_type_tag in &td.field_type_tags {
             write_string(w, field_type_tag)?;
         }
+        write_u32(w, td.aux_type_tags.len() as u32)?;
+        for aux_type_tag in &td.aux_type_tags {
+            write_string(w, aux_type_tag)?;
+        }
     }
 
     // Debug info (not serialized for now)
@@ -163,10 +167,16 @@ pub fn read_chunk<R: Read>(r: &mut R) -> Result<Chunk, BytecodeError> {
         for _ in 0..field_type_count {
             field_type_tags.push(read_string(r)?);
         }
+        let aux_type_count = read_u32(r)? as usize;
+        let mut aux_type_tags = Vec::with_capacity(aux_type_count);
+        for _ in 0..aux_type_count {
+            aux_type_tags.push(read_string(r)?);
+        }
         type_descriptors.push(super::TypeDescriptor {
             tag_name,
             field_names,
             field_type_tags,
+            aux_type_tags,
         });
     }
 

--- a/src/vm/mod.rs
+++ b/src/vm/mod.rs
@@ -72,6 +72,9 @@ pub struct TypeDescriptor {
     /// Field type tag names for struct types (parallel to field_names).
     /// Each entry is the tag_name of the field's type descriptor.
     pub field_type_tags: Vec<String>,
+    /// Auxiliary type tag names for container element types.
+    /// Vec → [elem_tag], Map → [key_tag, val_tag], Array → [elem_tag], others → [].
+    pub aux_type_tags: Vec<String>,
 }
 
 /// A compiled chunk of bytecode.

--- a/tests/snapshots/basic/print_collections.mc
+++ b/tests/snapshots/basic/print_collections.mc
@@ -44,3 +44,45 @@ struct Point {
 }
 let p = Point { x: 1, y: 2 };
 print_str(debug(p) + "\n");
+
+// struct-in-struct
+struct Line {
+    start: Point,
+    end: Point
+}
+let line = Line { start: Point { x: 0, y: 0 }, end: Point { x: 10, y: 20 } };
+print_str(debug(line) + "\n");
+
+// Vec<struct>
+let vp: Vec<Point> = new Vec<Point> {};
+vp.push(Point { x: 1, y: 2 });
+vp.push(Point { x: 3, y: 4 });
+print_str(debug(vp) + "\n");
+
+// Map<string, struct> (single entry to avoid ordering issues)
+let mp: Map<string, Point> = new Map<string, Point> {};
+mp.put_string("origin", Point { x: 0, y: 0 });
+print_str(debug(mp) + "\n");
+
+// nested Vec<Vec<int>>
+let vv: Vec<Vec<int>> = new Vec<Vec<int>> {};
+let v1: Vec<int> = new Vec<int> {};
+v1.push(1);
+v1.push(2);
+let v2: Vec<int> = new Vec<int> {};
+v2.push(3);
+v2.push(4);
+vv.push(v1);
+vv.push(v2);
+print_str(debug(vv) + "\n");
+
+// struct only debugged through Vec (never individually)
+struct Color {
+    r: int,
+    g: int,
+    b: int
+}
+let colors: Vec<Color> = new Vec<Color> {};
+colors.push(Color { r: 255, g: 0, b: 0 });
+colors.push(Color { r: 0, g: 255, b: 0 });
+print_str(debug(colors) + "\n");

--- a/tests/snapshots/basic/print_collections.stdout
+++ b/tests/snapshots/basic/print_collections.stdout
@@ -7,3 +7,8 @@ nil
 [[1, 2], [3, 4]]
 [hello, world]
 Point { x: 1, y: 2 }
+Line { start: Point { x: 0, y: 0 }, end: Point { x: 10, y: 20 } }
+[Point { x: 1, y: 2 }, Point { x: 3, y: 4 }]
+{origin: Point { x: 0, y: 0 }}
+[[1, 2], [3, 4]]
+[Color { r: 255, g: 0, b: 0 }, Color { r: 0, g: 255, b: 0 }]


### PR DESCRIPTION
## Summary

- TypeDescriptor に `aux_type_tags` フィールドを追加し、コンテナ型の要素型参照（Vec→[elem_tag], Map→[key_tag, val_tag]）を type_info ヒープオブジェクトに保持
- prelude の `_any_to_string` で aux type_info を使った再帰フォーマットを実装し、`Vec<Point>` や `Map<string, Point>` などネストした構造体の `debug()` 表示が正しく動作するように
- resolver で `nested_type_descriptors` を再帰収集し、コンテナ要素型（例: `Vec<Point>` の `Point`）のフィールド情報が空にならないよう codegen に完全な型情報を伝搬

## Test plan

- [x] `Vec<Point>` → `[Point { x: 1, y: 2 }, Point { x: 3, y: 4 }]`
- [x] `Map<string, Point>` → `{origin: Point { x: 0, y: 0 }}`
- [x] `Vec<Vec<int>>` → `[[1, 2], [3, 4]]`
- [x] struct-in-struct: `Line { start: Point { x: 0, y: 0 }, end: Point { x: 10, y: 20 } }`
- [x] `Vec<Color>` (Color は Vec 経由でのみ debug される) → `[Color { r: 255, g: 0, b: 0 }, ...]`
- [x] 既存のプリミティブ/コレクションテスト全てパス
- [x] `cargo fmt && cargo check && cargo test && cargo clippy` 全パス

🤖 Generated with [Claude Code](https://claude.com/claude-code)