### PR TITLE
feat: match dyn interface arm でメソッド呼び出しを可能にする

### DIFF
--- a/src/compiler/dump.rs
+++ b/src/compiler/dump.rs
@@ -1391,6 +1391,41 @@ impl ResolvedProgramPrinter {
                     self.print_expr(arg, &format!("{}arg: ", arg_prefix), &arg_child);
                 }
             }
+            ResolvedExpr::VtableMethodCall {
+                object,
+                vtable_slot,
+                method_index,
+                args,
+            } => {
+                self.write(&format!(
+                    "{}VtableMethodCall(vtable_slot={}, method_index={}, {} args)",
+                    prefix,
+                    vtable_slot,
+                    method_index,
+                    args.len()
+                ));
+                self.newline();
+                let has_args = !args.is_empty();
+                let obj_prefix = if has_args { "├── " } else { "└── " };
+                let obj_child = if has_args {
+                    format!("{}│   ", parent_prefix)
+                } else {
+                    format!("{}    ", parent_prefix)
+                };
+                self.write_indent_with(parent_prefix);
+                self.print_expr(object, &format!("{}object: ", obj_prefix), &obj_child);
+                for (i, arg) in args.iter().enumerate() {
+                    let is_last = i == args.len() - 1;
+                    let arg_prefix = if is_last { "└── " } else { "├── " };
+                    let arg_child = if is_last {
+                        format!("{}    ", parent_prefix)
+                    } else {
+                        format!("{}│   ", parent_prefix)
+                    };
+                    self.write_indent_with(parent_prefix);
+                    self.print_expr(arg, &format!("{}arg: ", arg_prefix), &arg_child);
+                }
+            }
             ResolvedExpr::AssociatedFunctionCall {
                 func_index,
                 args,

--- a/src/compiler/monomorphise.rs
+++ b/src/compiler/monomorphise.rs
@@ -82,6 +82,7 @@ fn mangle_type(ty: &Type) -> String {
         }
         Type::Var(id) => format!("T{}", id),
         Type::Param { name } => name.clone(),
+        Type::InterfaceBound { interface_name } => interface_name.clone(),
     }
 }
 
@@ -804,6 +805,7 @@ fn type_to_annotation(ty: &Type) -> crate::compiler::types::TypeAnnotation {
         },
         Type::Var(_) => TypeAnnotation::Named("any".to_string()), // Fallback for unresolved vars
         Type::Param { name } => TypeAnnotation::Named(name.clone()),
+        Type::InterfaceBound { interface_name } => TypeAnnotation::Named(interface_name.clone()),
         Type::Dyn => TypeAnnotation::Named("dyn".to_string()),
     }
 }

--- a/tests/snapshots/interface/match_dyn_interface.mc
+++ b/tests/snapshots/interface/match_dyn_interface.mc
@@ -34,7 +34,7 @@ fun show(d: dyn) -> string {
             return "int:" + v.to_string();
         }
         v: Describable => {
-            return "describable";
+            return "describable:" + v.describe();
         }
         _ => {
             return "other";

--- a/tests/snapshots/interface/match_dyn_interface.stdout
+++ b/tests/snapshots/interface/match_dyn_interface.stdout
@@ -1,4 +1,4 @@
 int:42
-describable
-describable
+describable:Point(10, 20)
+describable:rgb(255,128,0)
 other


### PR DESCRIPTION
## Summary

- `match dyn` の interface arm 内で vtable 経由のメソッド呼び出しを実現
- 新しい `Type::InterfaceBound` 型を導入し、typechecker → resolver → codegen パイプライン全体で動的ディスパッチをサポート
- 例: `match dyn d { v: Describable => { v.describe() } }` が動作するように

## 変更内容

- **types.rs**: `Type::InterfaceBound { interface_name }` バリアント追加
- **typechecker.rs**: interface arm 変数を `InterfaceBound` で型付け、メソッドシグネチャ解決
- **resolver.rs**: `ResolvedExpr::VtableMethodCall` 追加、vtable_slot 追跡
- **codegen.rs**: InterfaceMatch arm で raw value を unbox、`VtableMethodCall` → `CallDynamic` codegen
- **dump.rs / monomorphise.rs**: 新バリアント対応

## Test plan

- [x] `match_dyn_interface.mc` で `v.describe()` を vtable 経由で呼び出すテストに更新
- [x] `cargo fmt && cargo check && cargo test && cargo clippy` 全パス

Closes #211

🤖 Generated with [Claude Code](https://claude.ai/code)
via [Happy](https://happy.engineering)