### PR TITLE
refactor: 文字列操作系 opcode を std 関数に置き換え

### DIFF
--- a/src/compiler/resolver.rs
+++ b/src/compiler/resolver.rs
@@ -361,10 +361,10 @@ impl<'a> Resolver<'a> {
             interface_impls: HashSet::new(),
             interface_methods: HashMap::new(),
             builtins: vec![
-                "__value_to_string".to_string(),
+                "__typeof".to_string(),
+                "__heap_size".to_string(),
                 "len".to_string(),
                 "type_of".to_string(),
-                "parse_int".to_string(),
                 // Thread operations
                 "spawn".to_string(),
                 "channel".to_string(),
@@ -2937,13 +2937,13 @@ mod tests {
 
     #[test]
     fn test_simple_resolution() {
-        let program = resolve("let x = 42; __value_to_string(x);").unwrap();
+        let program = resolve("let x = 42; __typeof(x);").unwrap();
         assert_eq!(program.main_body.len(), 2);
     }
 
     #[test]
     fn test_undefined_variable() {
-        let result = resolve("__value_to_string(x);");
+        let result = resolve("__typeof(x);");
         assert!(result.is_err());
         assert!(result.unwrap_err().contains("undefined variable"));
     }

--- a/src/compiler/typechecker.rs
+++ b/src/compiler/typechecker.rs
@@ -2951,12 +2951,19 @@ impl TypeChecker {
         span: Span,
     ) -> Option<Type> {
         match name {
-            "__value_to_string" => {
-                // __value_to_string accepts any type, returns string
+            "__typeof" => {
+                // __typeof accepts any type, returns int (type tag)
                 for arg in args {
                     self.infer_expr(arg, env);
                 }
-                Some(Type::String)
+                Some(Type::Int)
+            }
+            "__heap_size" => {
+                // __heap_size accepts any type (ref), returns int (slot count)
+                for arg in args {
+                    self.infer_expr(arg, env);
+                }
+                Some(Type::Int)
             }
             "__syscall" => {
                 // __syscall(num, ...args) -> Int | String
@@ -3044,18 +3051,6 @@ impl TypeChecker {
                     self.infer_expr(arg, env);
                 }
                 Some(Type::String)
-            }
-            "parse_int" => {
-                if args.len() != 1 {
-                    self.errors
-                        .push(TypeError::new("parse_int expects 1 argument", span));
-                    return Some(Type::Int);
-                }
-                let arg_type = self.infer_expr(&mut args[0], env);
-                if let Err(e) = self.unify(&arg_type, &Type::String, span) {
-                    self.errors.push(e);
-                }
-                Some(Type::Int)
             }
             // Thread operations - for now just return appropriate types
             "spawn" | "channel" | "send" | "recv" | "join" => {

--- a/src/debugger/mod.rs
+++ b/src/debugger/mod.rs
@@ -162,14 +162,6 @@ impl Debugger {
                     self.stack.push(Value::I64(-v));
                 }
             }
-            Op::ValueToString => {
-                if let Some(val) = self.stack.last() {
-                    let s = self.format_value(val).to_string();
-                    self.output.push(s);
-                }
-                // ValueToString pops value and pushes a string, but in debugger we simplify
-                self.stack.pop();
-            }
             Op::Ret => {
                 self.finished = true;
                 self.status = "Program returned.".to_string();

--- a/src/ffi/load.rs
+++ b/src/ffi/load.rs
@@ -188,7 +188,7 @@ mod tests {
                 name: "main".to_string(),
                 arity: 0,
                 locals_count: 0,
-                code: vec![Op::I64Const(42), Op::ValueToString, Op::Ret],
+                code: vec![Op::I64Const(42), Op::TypeOf, Op::Ret],
                 stackmap: None,
                 local_types: vec![],
             },

--- a/src/jit/compiler_microop.rs
+++ b/src/jit/compiler_microop.rs
@@ -396,7 +396,6 @@ impl MicroOpJitCompiler {
                 | MicroOp::HeapLoadDyn { dst, .. }
                 | MicroOp::HeapLoad2 { dst, .. }
                 | MicroOp::StackPop { dst }
-                | MicroOp::ValueToString { dst, .. }
                 | MicroOp::HeapAlloc { dst, .. }
                 | MicroOp::HeapAllocDynSimple { dst, .. }
                 | MicroOp::StringConst { dst, .. } => {
@@ -569,7 +568,6 @@ impl MicroOpJitCompiler {
 
             // String operations
             MicroOp::StringConst { dst, idx } => self.emit_string_const(dst, *idx),
-            MicroOp::ValueToString { .. } => Err("ValueToString not supported in JIT".to_string()),
             // Heap allocation operations
             MicroOp::HeapAlloc { dst, args } => self.emit_heap_alloc(dst, args),
             MicroOp::HeapAllocDynSimple { dst, size } => self.emit_heap_alloc_dyn_simple(dst, size),

--- a/src/jit/compiler_microop_x86_64.rs
+++ b/src/jit/compiler_microop_x86_64.rs
@@ -176,7 +176,6 @@ impl MicroOpJitCompiler {
                 | MicroOp::HeapLoadDyn { dst, .. }
                 | MicroOp::HeapLoad2 { dst, .. }
                 | MicroOp::StackPop { dst }
-                | MicroOp::ValueToString { dst, .. }
                 | MicroOp::HeapAlloc { dst, .. }
                 | MicroOp::HeapAllocDynSimple { dst, .. }
                 | MicroOp::StringConst { dst, .. } => {
@@ -596,7 +595,6 @@ impl MicroOpJitCompiler {
 
             // String operations
             MicroOp::StringConst { dst, idx } => self.emit_string_const(dst, *idx),
-            MicroOp::ValueToString { .. } => Err("ValueToString not supported in JIT".to_string()),
             // Heap allocation operations
             MicroOp::HeapAlloc { dst, args } => self.emit_heap_alloc(dst, args),
             MicroOp::HeapAllocDynSimple { dst, size } => self.emit_heap_alloc_dyn_simple(dst, size),

--- a/src/lsp/mod.rs
+++ b/src/lsp/mod.rs
@@ -238,15 +238,7 @@ impl LanguageServer for MocaLanguageServer {
             "nil", "try", "catch", "throw", "import",
         ];
 
-        let builtins = [
-            "print",
-            "len",
-            "push",
-            "pop",
-            "type_of",
-            "to_string",
-            "parse_int",
-        ];
+        let builtins = ["print", "len", "push", "pop", "type_of", "to_string"];
 
         let mut items: Vec<CompletionItem> = keywords
             .iter()

--- a/src/vm/bytecode.rs
+++ b/src/vm/bytecode.rs
@@ -465,8 +465,8 @@ const OP_HEAP_STORE_DYN: u8 = 84;
 // System / Builtins
 const OP_SYSCALL: u8 = 86;
 const OP_GC_HINT: u8 = 87;
-const OP_VALUE_TO_STRING: u8 = 88;
-const OP_PARSE_INT: u8 = 91;
+const OP_TYPE_OF: u8 = 89;
+const OP_HEAP_SIZE: u8 = 90;
 // Exception Handling
 const OP_THROW: u8 = 93;
 const OP_TRY_BEGIN: u8 = 94;
@@ -693,8 +693,8 @@ fn write_op<W: Write>(w: &mut W, op: &Op) -> io::Result<()> {
             w.write_all(&[OP_GC_HINT])?;
             write_u32(w, *size as u32)?;
         }
-        Op::ValueToString => w.write_all(&[OP_VALUE_TO_STRING])?,
-        Op::ParseInt => w.write_all(&[OP_PARSE_INT])?,
+        Op::TypeOf => w.write_all(&[OP_TYPE_OF])?,
+        Op::HeapSize => w.write_all(&[OP_HEAP_SIZE])?,
         // Exception Handling
         Op::Throw => w.write_all(&[OP_THROW])?,
         Op::TryBegin(target) => {
@@ -887,8 +887,8 @@ fn read_op<R: Read>(r: &mut R) -> Result<Op, BytecodeError> {
         // System / Builtins
         OP_SYSCALL => Op::Syscall(read_u32(r)? as usize, read_u32(r)? as usize),
         OP_GC_HINT => Op::GcHint(read_u32(r)? as usize),
-        OP_VALUE_TO_STRING => Op::ValueToString,
-        OP_PARSE_INT => Op::ParseInt,
+        OP_TYPE_OF => Op::TypeOf,
+        OP_HEAP_SIZE => Op::HeapSize,
         // Exception Handling
         OP_THROW => Op::Throw,
         OP_TRY_BEGIN => Op::TryBegin(read_u32(r)? as usize),
@@ -1121,7 +1121,7 @@ mod tests {
                     Op::I64Const(10),
                     Op::I64Const(20),
                     Op::Call(0, 2),
-                    Op::ValueToString,
+                    Op::TypeOf,
                     Op::Ret,
                 ],
                 stackmap: None,
@@ -1331,8 +1331,8 @@ mod tests {
             // System / Builtins
             Op::Syscall(7, 2),
             Op::GcHint(1024),
-            Op::ValueToString,
-            Op::ParseInt,
+            Op::TypeOf,
+            Op::HeapSize,
             // Exception Handling
             Op::Throw,
             Op::TryBegin(100),

--- a/src/vm/microop.rs
+++ b/src/vm/microop.rs
@@ -509,12 +509,6 @@ pub enum MicroOp {
         type_info: VReg,
         iface_desc: VReg,
     },
-    /// Convert any value to its string representation.
-    /// dst = to_string(src) (Ref to newly allocated heap string)
-    ValueToString {
-        dst: VReg,
-        src: VReg,
-    },
     // ========================================
     // Stack Bridge (for Raw op interop)
     // ========================================

--- a/src/vm/microop_converter.rs
+++ b/src/vm/microop_converter.rs
@@ -1777,24 +1777,6 @@ pub fn convert(func: &Function) -> ConvertedFunction {
                 micro_ops.push(MicroOp::UMul128Hi { dst, a, b });
                 vstack.push(Vse::Reg(dst));
             }
-            Op::ValueToString => {
-                let src = pop_vreg(
-                    &mut vstack,
-                    &mut micro_ops,
-                    &mut next_temp,
-                    &mut max_temp,
-                    &mut vreg_types,
-                );
-                let dst = alloc_temp(
-                    &mut next_temp,
-                    &mut max_temp,
-                    &mut vreg_types,
-                    ValueType::I64,
-                );
-                micro_ops.push(MicroOp::ValueToString { dst, src });
-                vstack.push(Vse::Reg(dst));
-            }
-
             // ============================================================
             // Heap allocation operations
             // ============================================================

--- a/src/vm/ops.rs
+++ b/src/vm/ops.rs
@@ -172,9 +172,11 @@ pub enum Op {
     // ========================================
     Syscall(usize, usize),
     GcHint(usize),
-    ValueToString,
-    ParseInt,
     UMul128Hi,
+    /// Returns the runtime type tag of a value: 0=I64, 1=F64, 2=Bool, 3=Null, 4=Ref
+    TypeOf,
+    /// Returns the number of slots in a heap object
+    HeapSize,
 
     // ========================================
     // Exception Handling
@@ -333,9 +335,9 @@ impl Op {
             Op::HeapOffsetRef => "HeapOffsetRef",
             Op::Syscall(_, _) => "Syscall",
             Op::GcHint(_) => "GcHint",
-            Op::ValueToString => "ValueToString",
-            Op::ParseInt => "ParseInt",
             Op::UMul128Hi => "UMul128Hi",
+            Op::TypeOf => "TypeOf",
+            Op::HeapSize => "HeapSize",
             Op::Throw => "Throw",
             Op::TryBegin(_) => "TryBegin",
             Op::TryEnd => "TryEnd",

--- a/src/vm/verifier.rs
+++ b/src/vm/verifier.rs
@@ -467,8 +467,8 @@ impl Verifier {
             // System / Builtins
             Op::Syscall(_, argc) => (*argc, 1), // pops argc args, pushes result
             Op::GcHint(_) => (0, 0),
-            Op::ValueToString => (1, 1), // pops value, pushes string
-            Op::ParseInt => (1, 1),      // pops string, pushes int
+            Op::TypeOf => (1, 1),   // pops value, pushes type tag
+            Op::HeapSize => (1, 1), // pops ref, pushes slot count
             // Exception handling
             Op::Throw => (1, 0),
             Op::TryBegin(_) => (0, 0),

--- a/std/prelude_test.mc
+++ b/std/prelude_test.mc
@@ -67,23 +67,23 @@ fun _test_str_contains_empty() {
 // Parsing Functions Tests
 // ============================================================================
 
-fun _test_std_parse_int_positive() {
-    assert_eq(std_parse_int("42"), 42, "parse '42' as 42");
-    assert_eq(std_parse_int("0"), 0, "parse '0' as 0");
-    assert_eq(std_parse_int("12345"), 12345, "parse '12345' as 12345");
+fun _test_parse_int_positive() {
+    assert_eq(parse_int("42"), 42, "parse '42' as 42");
+    assert_eq(parse_int("0"), 0, "parse '0' as 0");
+    assert_eq(parse_int("12345"), 12345, "parse '12345' as 12345");
 }
 
-fun _test_std_parse_int_negative() {
-    assert_eq(std_parse_int("-42"), -42, "parse '-42' as -42");
-    assert_eq(std_parse_int("-1"), -1, "parse '-1' as -1");
-    assert_eq(std_parse_int("-12345"), -12345, "parse '-12345' as -12345");
+fun _test_parse_int_negative() {
+    assert_eq(parse_int("-42"), -42, "parse '-42' as -42");
+    assert_eq(parse_int("-1"), -1, "parse '-1' as -1");
+    assert_eq(parse_int("-12345"), -12345, "parse '-12345' as -12345");
 }
 
-fun _test_std_parse_int_whitespace() {
-    assert_eq(std_parse_int("  42"), 42, "parse '  42' with leading whitespace");
-    assert_eq(std_parse_int("42  "), 42, "parse '42  ' with trailing whitespace");
-    assert_eq(std_parse_int("  42  "), 42, "parse '  42  ' with both whitespace");
-    assert_eq(std_parse_int("  -42  "), -42, "parse '  -42  ' with whitespace");
+fun _test_parse_int_whitespace() {
+    assert_eq(parse_int("  42"), 42, "parse '  42' with leading whitespace");
+    assert_eq(parse_int("42  "), 42, "parse '42  ' with trailing whitespace");
+    assert_eq(parse_int("  42  "), 42, "parse '  42  ' with both whitespace");
+    assert_eq(parse_int("  -42  "), -42, "parse '  -42  ' with whitespace");
 }
 
 // ============================================================================

--- a/tests/snapshots/asm/basic_emit.mc
+++ b/tests/snapshots/asm/basic_emit.mc
@@ -1,5 +1,5 @@
-// Basic asm block with PushInt and ValueToString
+// Basic asm block with PushInt and TypeOf
 asm {
     __emit("PushInt", 42);
-    __emit("ValueToString");
+    __emit("TypeOf");
 };


### PR DESCRIPTION
## Summary
- **ParseInt 廃止**: `std_parse_int` を `parse_int` にリネームし、`Op::ParseInt` opcode を削除
- **ValueToString 廃止**: `__typeof` / `__heap_size` プリミティブを追加し、`__value_to_string` を moca 関数として再実装、`Op::ValueToString` opcode を削除
- 高レベル opcode 2つ削除、低レベルプリミティブ 2つ追加（ネット変更: ±0）

## Test plan
- [x] 既存テスト全パス（`cargo test`）
- [x] `parse_int` が std 関数として動作（builtin_functions.mc）
- [x] `__value_to_string` が moca 実装で動作（print_fallback.mc, io_error.mc）
- [x] `cargo clippy` パス

Closes #190

🤖 Generated with [Claude Code](https://claude.com/claude-code)