### PR TITLE
refactor: Type::Vector/Array/Map を GenericStruct に統一

### DIFF
--- a/src/compiler/linter.rs
+++ b/src/compiler/linter.rs
@@ -371,7 +371,6 @@ pub struct PreferIndexAccess;
 impl PreferIndexAccess {
     fn is_vec_or_map(object_type: &Option<Type>) -> bool {
         match object_type {
-            Some(Type::Vector(_)) | Some(Type::Map(_, _)) => true,
             Some(Type::GenericStruct { name, .. }) => name == "Vec" || name == "Map",
             _ => false,
         }

--- a/tests/snapshots/errors/builtin_push_type_error.stderr
+++ b/tests/snapshots/errors/builtin_push_type_error.stderr
@@ -1,1 +1,1 @@
-cannot call method
+undefined method `push` on struct `Array`


### PR DESCRIPTION
## Summary
- `Type` enum から `Array`, `Vector`, `Map` の専用バリアントを削除し、`GenericStruct` に統一
- ヘルパーメソッド (`is_array`, `is_vec`, `is_map`, `collection_element_type`, `map_key_value_types`) を追加
- typechecker, codegen, monomorphise, desugar, linter, resolver の全パターンマッチを更新
- Vector↔GenericStruct<Vec>, Map↔GenericStruct<Map> の互換 unification コードを削除（不要に）
- Display・mangle_type の小文字表記、print fallback の振り分けを維持

## Test plan
- [x] `cargo fmt` — フォーマット済み
- [x] `cargo check` — コンパイル通過
- [x] `cargo test` — 全18テスト通過
- [x] `cargo clippy` — 警告なし

Closes #217

🤖 Generated with [Claude Code](https://claude.com/claude-code)