### PR TITLE
refactor: TypeDescLoad/InterfaceDescLoad を汎用 GlobalGet に統一

### DIFF
--- a/src/vm/bytecode.rs
+++ b/src/vm/bytecode.rs
@@ -504,8 +504,8 @@ const OP_I64_SHR_U: u8 = 115;
 const OP_F64_REINTERPRET_AS_I64: u8 = 116;
 const OP_UMUL128_HI: u8 = 117;
 const OP_HEAP_OFFSET_REF: u8 = 118;
-const OP_TYPE_DESC_LOAD: u8 = 119;
-const OP_IFACE_DESC_LOAD: u8 = 120;
+const OP_GLOBAL_GET: u8 = 119;
+// 120 is unused (was OP_IFACE_DESC_LOAD)
 const OP_CALL_DYNAMIC: u8 = 121;
 const OP_VTABLE_LOOKUP: u8 = 122;
 
@@ -724,15 +724,9 @@ fn write_op<W: Write>(w: &mut W, op: &Op) -> io::Result<()> {
             write_u32(w, *argc as u32)?;
         }
 
-        // Type Descriptor
-        Op::TypeDescLoad(idx) => {
-            w.write_all(&[OP_TYPE_DESC_LOAD])?;
-            write_u32(w, *idx as u32)?;
-        }
-
-        // Interface Descriptor
-        Op::InterfaceDescLoad(idx) => {
-            w.write_all(&[OP_IFACE_DESC_LOAD])?;
+        // Globals
+        Op::GlobalGet(idx) => {
+            w.write_all(&[OP_GLOBAL_GET])?;
             write_u32(w, *idx as u32)?;
         }
 
@@ -910,10 +904,8 @@ fn read_op<R: Read>(r: &mut R) -> Result<Op, BytecodeError> {
         OP_CALL_INDIRECT => Op::CallIndirect(read_u32(r)? as usize),
 
         // Type Descriptor
-        OP_TYPE_DESC_LOAD => Op::TypeDescLoad(read_u32(r)? as usize),
-
-        // Interface Descriptor
-        OP_IFACE_DESC_LOAD => Op::InterfaceDescLoad(read_u32(r)? as usize),
+        // Globals
+        OP_GLOBAL_GET => Op::GlobalGet(read_u32(r)? as usize),
 
         // Dynamic call by func_index on stack
         OP_CALL_DYNAMIC => Op::CallDynamic(read_u32(r)? as usize),

--- a/src/vm/microop.rs
+++ b/src/vm/microop.rs
@@ -490,15 +490,9 @@ pub enum MicroOp {
         dst: VReg,
         idx: usize,
     },
-    /// Load pre-allocated type descriptor reference.
-    /// dst = type_descriptor_refs[idx]
-    TypeDescLoad {
-        dst: VReg,
-        idx: usize,
-    },
-    /// Load pre-allocated interface descriptor reference.
-    /// dst = interface_descriptor_refs[idx]
-    InterfaceDescLoad {
+    /// Load a global value.
+    /// dst = globals[idx]
+    GlobalGet {
         dst: VReg,
         idx: usize,
     },

--- a/src/vm/microop_converter.rs
+++ b/src/vm/microop_converter.rs
@@ -1705,24 +1705,14 @@ pub fn convert(func: &Function) -> ConvertedFunction {
                 micro_ops.push(MicroOp::StringConst { dst, idx: *idx });
                 vstack.push(Vse::RegRef(dst));
             }
-            Op::TypeDescLoad(idx) => {
+            Op::GlobalGet(idx) => {
                 let dst = alloc_temp(
                     &mut next_temp,
                     &mut max_temp,
                     &mut vreg_types,
                     ValueType::Ref,
                 );
-                micro_ops.push(MicroOp::TypeDescLoad { dst, idx: *idx });
-                vstack.push(Vse::RegRef(dst));
-            }
-            Op::InterfaceDescLoad(idx) => {
-                let dst = alloc_temp(
-                    &mut next_temp,
-                    &mut max_temp,
-                    &mut vreg_types,
-                    ValueType::Ref,
-                );
-                micro_ops.push(MicroOp::InterfaceDescLoad { dst, idx: *idx });
+                micro_ops.push(MicroOp::GlobalGet { dst, idx: *idx });
                 vstack.push(Vse::RegRef(dst));
             }
             Op::VtableLookup => {

--- a/src/vm/ops.rs
+++ b/src/vm/ops.rs
@@ -215,18 +215,12 @@ pub enum Op {
     CallDynamic(usize), // (argc) — number of arguments
 
     // ========================================
-    // Type Descriptor
+    // Globals
     // ========================================
-    /// Push pre-allocated type descriptor reference onto the stack.
-    /// The index refers to the type_descriptors table in the Chunk.
-    TypeDescLoad(usize),
-
-    // ========================================
-    // Interface Descriptor
-    // ========================================
-    /// Push pre-allocated interface descriptor reference onto the stack.
-    /// The index refers to the interface_descriptors table in the Chunk.
-    InterfaceDescLoad(usize),
+    /// Push a pre-allocated global value onto the stack.
+    /// The index refers to the globals table in the VM.
+    /// Layout: globals[0..T] = type descriptor refs, globals[T..T+I] = interface descriptor refs.
+    GlobalGet(usize),
 
     /// Vtable lookup: pops iface_desc_ref and type_info_ref from stack.
     /// Searches type_info's vtable entries for matching iface_desc_ref (by RefEq).
@@ -352,8 +346,7 @@ impl Op {
             Op::CallIndirect(_) => "CallIndirect",
             Op::CallDynamic(_) => "CallDynamic",
             Op::VtableLookup => "VtableLookup",
-            Op::TypeDescLoad(_) => "TypeDescLoad",
-            Op::InterfaceDescLoad(_) => "InterfaceDescLoad",
+            Op::GlobalGet(_) => "GlobalGet",
         }
     }
 }

--- a/src/vm/verifier.rs
+++ b/src/vm/verifier.rs
@@ -491,11 +491,8 @@ impl Verifier {
             // Dynamic call by func_index on stack
             Op::CallDynamic(argc) => (argc + 1, 1), // pops func_index + argc args, pushes result
 
-            // Type Descriptor
-            Op::TypeDescLoad(_) => (0, 1), // pushes type descriptor ref
-
-            // Interface Descriptor
-            Op::InterfaceDescLoad(_) => (0, 1), // pushes interface descriptor ref
+            // Globals
+            Op::GlobalGet(_) => (0, 1), // pushes global value
 
             // Vtable lookup
             Op::VtableLookup => (2, 1), // pops iface_desc_ref + type_info_ref, pushes vtable_ref or null


### PR DESCRIPTION
## Summary

- `Op::TypeDescLoad(usize)` と `Op::InterfaceDescLoad(usize)` の2つの専用命令を、汎用的な `Op::GlobalGet(usize)` に統一
- VMに `globals: Vec<Value>` テーブルを導入（`type_descriptor_refs` + `interface_descriptor_refs` を統合）
- globals テーブルのレイアウト: `[type_desc_refs..., iface_desc_refs...]`
- codegen でフラグビット (`1 << 31`) を使った fixup パスにより、interface descriptor のインデックスを解決

## 変更ファイル

| ファイル | 変更内容 |
|---|---|
| `src/vm/ops.rs` | `TypeDescLoad`/`InterfaceDescLoad` → `GlobalGet` |
| `src/vm/vm.rs` | `globals` テーブル導入、`init_globals()` メソッド |
| `src/vm/microop.rs` | `MicroOp::GlobalGet` に統合 |
| `src/vm/microop_converter.rs` | 変換更新 |
| `src/vm/bytecode.rs` | opcode 119 を `OP_GLOBAL_GET` に |
| `src/vm/verifier.rs` | スタック効果の更新 |
| `src/compiler/codegen.rs` | emit + fixup パス追加 |
| `src/compiler/dump.rs` | 表示更新（type/iface 区別のコメント付き） |

## Test plan

- [x] `cargo fmt`
- [x] `cargo check`
- [x] `cargo test` — 全344テストパス
- [x] `cargo clippy` — 警告なし

Closes #187

🤖 Generated with [Claude Code](https://claude.ai/code)