### PR TITLE
feat: Vec<T> と Map<K,V> に impl ToString を追加

### DIFF
--- a/src/compiler/monomorphise.rs
+++ b/src/compiler/monomorphise.rs
@@ -51,7 +51,7 @@ impl Instantiation {
 }
 
 /// Mangle a type into a string suitable for use in a function name.
-fn mangle_type(ty: &Type) -> String {
+pub fn mangle_type(ty: &Type) -> String {
     match ty {
         Type::Int => "int".to_string(),
         Type::Float => "float".to_string(),

--- a/src/compiler/typechecker.rs
+++ b/src/compiler/typechecker.rs
@@ -1152,8 +1152,8 @@ impl TypeChecker {
                 "string" => Type::String,
                 _ => unreachable!(),
             })
-        } else if is_builtin_type {
-            None // Builtin types don't have a struct definition
+        } else if is_builtin_type && impl_block.interface_name.is_none() {
+            None // Builtin types without interface impl don't need self_type
         } else if let Some(info) = self.structs.get(struct_name).cloned() {
             // For generic structs, create GenericStruct with type params
             if !impl_block.type_params.is_empty() {
@@ -1192,8 +1192,9 @@ impl TypeChecker {
                     .get(struct_name)
                     .and_then(|methods| methods.get(&method.name))
                     .cloned()
-            } else if is_builtin_type {
-                // For builtin types (Vec/Map), skip body checking entirely.
+            } else if is_builtin_type && impl_block.interface_name.is_none() {
+                // For builtin types (Vec/Map) without an interface impl,
+                // skip body checking entirely.
                 // Bodies use low-level intrinsics that aren't type-checkable.
                 // Method signatures are already registered via register_impl_methods.
                 None

--- a/std/prelude.mc
+++ b/std/prelude.mc
@@ -1761,6 +1761,46 @@ impl<K, V> Map<K, V> {
 }
 
 // ============================================================================
+// ToString for Vec and Map
+// ============================================================================
+
+impl<T> ToString for Vec<T> {
+    fun to_string(self) -> string {
+        if self.len == 0 { return "[]"; }
+        let result = "[";
+        let i = 0;
+        while i < self.len {
+            if i > 0 { result = result + ", "; }
+            result = result + debug(self.data[i] as dyn);
+            i = i + 1;
+        }
+        return result + "]";
+    }
+}
+
+impl<K, V> ToString for Map<K, V> {
+    fun to_string(self) -> string {
+        if self.hm_size == 0 { return "{}"; }
+        let result = "{";
+        let first = true;
+        let bi = 0;
+        while bi < self.hm_capacity {
+            let entry_ptr = self.hm_buckets[bi];
+            while entry_ptr != nil {
+                if !first { result = result + ", "; }
+                first = false;
+                let k = __heap_load(entry_ptr, 0);
+                let v = __heap_load(entry_ptr, 1);
+                result = result + debug(k as dyn) + ": " + debug(v as dyn);
+                entry_ptr = __heap_load(entry_ptr, 2);
+            }
+            bi = bi + 1;
+        }
+        return result + "}";
+    }
+}
+
+// ============================================================================
 // Random Number Generation (LCG - Linear Congruential Generator)
 // ============================================================================
 


### PR DESCRIPTION
## Summary

- `impl<T> ToString for Vec<T>` と `impl<K,V> ToString for Map<K,V>` を `std/prelude.mc` に追加
- `debug()` を使い、要素の ToString があれば呼び出し、なければ標準の方法でフォーマット
- ビルトイン型（Vec/Map）でも interface impl があれば型チェッカーがボディを検査するよう修正
- モノモーフ化後のジェネリック型に対する vtable エントリの正しいルックアップを実装

### 出力例

```
[1, 2, 3]
[Point { x: 1, y: 2 }, Point { x: 3, y: 4 }]
{a: 1, b: 2, c: 3}
{origin: Point { x: 0, y: 0 }}
```

## 修正した問題

1. **typechecker**: `is_builtin_type` チェックが interface impl のボディも skip していた → `interface_name.is_none()` 条件を追加
2. **resolver**: `type_to_impl_name` が GenericStruct に対してベース名のみ返していた → mangled name を生成するよう修正
3. **resolver**: モノモーフ化後の impl ブロックが `interface_impls` に登録されていなかった → 登録を追加
4. **resolver**: `TypeAnnotation::to_type()` 由来の空フィールド `Type::Struct` が dyn descriptor で正しいフィールド情報を持たなかった → `enrich_type_with_struct_fields` で補完

Closes: #145 Phase 4

## Test plan

- [x] `cargo fmt && cargo check && cargo test && cargo clippy` — all pass
- [x] `cargo run -- lint std/prelude.mc` — no warnings
- [x] 既存の `print_collections` スナップショットテストが正しい出力を検証
- [x] 手動テスト: Vec<int>, Vec<Point>, Vec<Color>, Map<string,int>, Map<string,Point>, Vec<Vec<int>>

🤖 Generated with [Claude Code](https://claude.com/claude-code)