### PR TITLE
perf: print(int) 大量出力のベンチマークテスト追加

### DIFF
--- a/tests/snapshot_tests.rs
+++ b/tests/snapshot_tests.rs
@@ -1064,6 +1064,19 @@ fn rust_string_interpolation<W: Write>(writer: &mut W) {
     writeln!(writer, "{}", total).unwrap();
 }
 
+#[cfg(feature = "jit")]
+fn rust_print_int<W: Write>(writer: &mut W) {
+    // Same LCG as moca _print_lcg_next
+    let mut seed: i64 = 42;
+    for _ in 0..100000 {
+        seed = (seed * 1103515245 + 12345) % 2147483648;
+        if seed < 0 {
+            seed = -seed;
+        }
+        writeln!(writer, "{}", seed % 1000000).unwrap();
+    }
+}
+
 /// Run a moca file with JIT enabled and measure execution time
 #[cfg(feature = "jit")]
 fn run_performance_benchmark(path: &Path) -> (std::time::Duration, String, usize) {
@@ -1208,6 +1221,10 @@ fn snapshot_performance() {
     // Test string interpolation with Rust reference
     let string_interp_path = perf_dir.join("string_interpolation.mc");
     run_performance_test(&string_interp_path, |w| rust_string_interpolation(w));
+
+    // Test print(int) bulk output with Rust reference
+    let print_int_path = perf_dir.join("print_int.mc");
+    run_performance_test(&print_int_path, |w| rust_print_int(w));
 }
 
 // ============================================================================

--- a/tests/snapshots/performance/print_int.mc
+++ b/tests/snapshots/performance/print_int.mc
@@ -1,0 +1,24 @@
+// Benchmark: print(int) bulk output
+// Measures _int_to_string conversion + I/O performance.
+// Uses LCG for deterministic number generation (JIT-compilable).
+
+fun _print_lcg_next(seed: int) -> int {
+    let s = seed * 1103515245 + 12345;
+    s = s % 2147483648;
+    if s < 0 {
+        s = 0 - s;
+    }
+    return s;
+}
+
+fun print_int_benchmark() {
+    let seed = 42;
+    let i = 0;
+    while i < 100000 {
+        seed = _print_lcg_next(seed);
+        print(seed % 1000000);
+        i = i + 1;
+    }
+}
+
+print_int_benchmark();


### PR DESCRIPTION
## Summary
- 100K回の `print(int)` 呼び出しベンチマーク (`print_int.mc`) を追加
- Rust リファレンス実装との比較で `_int_to_string` + I/O のボトルネックを計測可能に
- ローカル結果: moca 0.59s vs Rust 0.01s (51x) — 文字列変換+I/Oの改善余地を可視化

## Test plan
- [x] `moca lint` パス
- [x] `cargo test --features jit snapshot_performance` パス（出力一致確認済み）
- [x] `cargo fmt && cargo check && cargo clippy` パス

Closes #236

🤖 Generated with [Claude Code](https://claude.ai/code)