### PR TITLE
fix(monomorphise): Expr::Block 内の rewrite 漏れを修正

### DIFF
--- a/src/compiler/monomorphise.rs
+++ b/src/compiler/monomorphise.rs
@@ -1845,6 +1845,20 @@ fn rewrite_expr(expr: &Expr, instantiations: &HashSet<Instantiation>) -> Expr {
             inferred_type: inferred_type.clone(),
             is_implicit: *is_implicit,
         },
+        Expr::Block {
+            statements,
+            expr,
+            span,
+            inferred_type,
+        } => Expr::Block {
+            statements: statements
+                .iter()
+                .map(|s| rewrite_statement(s, instantiations))
+                .collect(),
+            expr: Box::new(rewrite_expr(expr, instantiations)),
+            span: *span,
+            inferred_type: inferred_type.clone(),
+        },
         // Literals and identifiers don't need rewriting
         // Note: NewLiteral is already desugared before monomorphisation
         _ => expr.clone(),


### PR DESCRIPTION
## Summary

- `rewrite_expr` に `Expr::Block` のケースを追加し、Block 内の式も再帰的に書き換えるようにした
- desugar が Vec/Map リテラルを `Expr::Block` に展開するが、`rewrite_expr` にこのケースがなく `_ => expr.clone()` でスルーされていた
- これにより `Vec::uninit` → `Vec__int::uninit` への書き換えが Block 内で行われなかった

## Test plan

- [x] `cargo fmt && cargo check && cargo test && cargo clippy` 全パス
- [x] `--dump-monomorphised` で `AssociatedFunctionCall: Vec__int::uninit` に書き換えられていることを確認

## Note

`__alloc_heap` の typed allocation 復活 (codegen) と JIT typed stride 有効化は、この PR の後に別 PR で対応予定。
codegen の typed allocation は JIT の emit_heap_load2/store2 が Tagged stride のみ対応のため、セットで変更しないと stride 不整合が起きる。

Closes #246

🤖 Generated with [Claude Code](https://claude.com/claude-code)