### PR TITLE
feat(jit): HeapLoadDyn/HeapStoreDyn に ElemKind typed stride を追加

### DIFF
--- a/src/compiler/dump.rs
+++ b/src/compiler/dump.rs
@@ -1850,8 +1850,8 @@ impl<'a> Disassembler<'a> {
                 .push_str(&format!("HeapAllocDynSimple({:?})", ek)),
             Op::HeapLoad(offset) => self.output.push_str(&format!("HeapLoad {}", offset)),
             Op::HeapStore(offset) => self.output.push_str(&format!("HeapStore {}", offset)),
-            Op::HeapLoadDyn => self.output.push_str("HeapLoadDyn"),
-            Op::HeapStoreDyn => self.output.push_str("HeapStoreDyn"),
+            Op::HeapLoadDyn(ek) => self.output.push_str(&format!("HeapLoadDyn({:?})", ek)),
+            Op::HeapStoreDyn(ek) => self.output.push_str(&format!("HeapStoreDyn({:?})", ek)),
             Op::HeapLoad2(_) => self.output.push_str("HeapLoad2"),
             Op::HeapStore2(_) => self.output.push_str("HeapStore2"),
             Op::HeapOffsetRef => self.output.push_str("HeapOffsetRef"),
@@ -2348,8 +2348,14 @@ fn format_single_microop(output: &mut String, mop: &MicroOp, chunk: &Chunk) {
             format_vreg(src),
             offset
         )),
-        MicroOp::HeapLoadDyn { dst, obj, idx } => output.push_str(&format!(
-            "HeapLoadDyn {}, {}, {}",
+        MicroOp::HeapLoadDyn {
+            dst,
+            obj,
+            idx,
+            elem_kind,
+        } => output.push_str(&format!(
+            "HeapLoadDyn({:?}) {}, {}, {}",
+            elem_kind,
             format_vreg(dst),
             format_vreg(obj),
             format_vreg(idx)
@@ -2364,8 +2370,14 @@ fn format_single_microop(output: &mut String, mop: &MicroOp, chunk: &Chunk) {
             offset,
             format_vreg(src)
         )),
-        MicroOp::HeapStoreDyn { obj, idx, src } => output.push_str(&format!(
-            "HeapStoreDyn {}, {}, {}",
+        MicroOp::HeapStoreDyn {
+            obj,
+            idx,
+            src,
+            elem_kind,
+        } => output.push_str(&format!(
+            "HeapStoreDyn({:?}) {}, {}, {}",
+            elem_kind,
             format_vreg(obj),
             format_vreg(idx),
             format_vreg(src)

--- a/src/vm/microop.rs
+++ b/src/vm/microop.rs
@@ -430,10 +430,12 @@ pub enum MicroOp {
         offset: usize,
     },
     /// dst = heap[obj][idx] (dynamic index access)
+    /// elem_kind: Tagged = legacy 16B tagged slots, Typed = 8B untagged elements
     HeapLoadDyn {
         dst: VReg,
         obj: VReg,
         idx: VReg,
+        elem_kind: super::heap::ElemKind,
     },
     /// heap[dst_obj][offset] = src (static offset field store)
     HeapStore {
@@ -442,10 +444,12 @@ pub enum MicroOp {
         src: VReg,
     },
     /// heap[obj][idx] = src (dynamic index store)
+    /// elem_kind: Tagged = legacy 16B tagged slots, Typed = 8B untagged elements
     HeapStoreDyn {
         obj: VReg,
         idx: VReg,
         src: VReg,
+        elem_kind: super::heap::ElemKind,
     },
     /// dst = heap[heap[obj][0]][idx] (ptr-indirect dynamic access)
     /// elem_kind: Tagged = legacy 16B tagged slots, I64/Ref = 8B untagged elements

--- a/src/vm/microop_converter.rs
+++ b/src/vm/microop_converter.rs
@@ -1445,7 +1445,7 @@ pub fn convert(func: &Function) -> ConvertedFunction {
                 });
                 vstack.push(Vse::Reg(dst));
             }
-            Op::HeapLoadDyn => {
+            Op::HeapLoadDyn(ek) => {
                 // pop index, pop ref, push ref[index]
                 let idx = pop_vreg(
                     &mut vstack,
@@ -1467,7 +1467,12 @@ pub fn convert(func: &Function) -> ConvertedFunction {
                     &mut vreg_types,
                     ValueType::I64,
                 );
-                micro_ops.push(MicroOp::HeapLoadDyn { dst, obj, idx });
+                micro_ops.push(MicroOp::HeapLoadDyn {
+                    dst,
+                    obj,
+                    idx,
+                    elem_kind: *ek,
+                });
                 vstack.push(Vse::Reg(dst));
             }
             Op::HeapStore(offset) => {
@@ -1492,7 +1497,7 @@ pub fn convert(func: &Function) -> ConvertedFunction {
                     src,
                 });
             }
-            Op::HeapStoreDyn => {
+            Op::HeapStoreDyn(ek) => {
                 // pop value, pop index, pop ref → ref[index] = value
                 let src = pop_vreg(
                     &mut vstack,
@@ -1515,7 +1520,12 @@ pub fn convert(func: &Function) -> ConvertedFunction {
                     &mut max_temp,
                     &mut vreg_types,
                 );
-                micro_ops.push(MicroOp::HeapStoreDyn { obj, idx, src });
+                micro_ops.push(MicroOp::HeapStoreDyn {
+                    obj,
+                    idx,
+                    src,
+                    elem_kind: *ek,
+                });
             }
             Op::HeapLoad2(ek) => {
                 // pop index, pop ref → push heap[heap[ref][0]][idx]

--- a/src/vm/ops.rs
+++ b/src/vm/ops.rs
@@ -158,8 +158,12 @@ pub enum Op {
     HeapAllocDynSimple(super::heap::ElemKind),
     HeapLoad(usize),
     HeapStore(usize),
-    HeapLoadDyn,
-    HeapStoreDyn,
+    /// Dynamic index load: pop idx, pop ref → push heap[ref][idx]
+    /// ElemKind: Tagged = legacy 16B (tag+payload), Typed = 8B (payload only)
+    HeapLoadDyn(super::heap::ElemKind),
+    /// Dynamic index store: pop val, pop idx, pop ref → heap[ref][idx] = val
+    /// ElemKind: Tagged = legacy 16B (tag+payload), Typed = 8B (payload only)
+    HeapStoreDyn(super::heap::ElemKind),
     /// Indirect load: pop idx, pop ref → push heap[heap[ref][0]][idx]
     /// ElemKind: Tagged = legacy 16B, I64/Ref = 8B untagged
     HeapLoad2(super::heap::ElemKind),
@@ -324,8 +328,8 @@ impl Op {
             Op::HeapAllocDynSimple(_) => "HeapAllocDynSimple",
             Op::HeapLoad(_) => "HeapLoad",
             Op::HeapStore(_) => "HeapStore",
-            Op::HeapLoadDyn => "HeapLoadDyn",
-            Op::HeapStoreDyn => "HeapStoreDyn",
+            Op::HeapLoadDyn(_) => "HeapLoadDyn",
+            Op::HeapStoreDyn(_) => "HeapStoreDyn",
             Op::HeapLoad2(_) => "HeapLoad2",
             Op::HeapStore2(_) => "HeapStore2",
             Op::HeapOffsetRef => "HeapOffsetRef",

--- a/src/vm/verifier.rs
+++ b/src/vm/verifier.rs
@@ -459,8 +459,8 @@ impl Verifier {
             Op::HeapAllocDynSimple(_) => (1, 1), // pops size, pushes ref (null-initialized)
             Op::HeapLoad(_) => (1, 1),   // pops ref, pushes value
             Op::HeapStore(_) => (2, 0),  // pops ref and value
-            Op::HeapLoadDyn => (2, 1),   // pops ref and index, pushes value
-            Op::HeapStoreDyn => (3, 0),  // pops ref, index, and value
+            Op::HeapLoadDyn(_) => (2, 1), // pops ref and index, pushes value
+            Op::HeapStoreDyn(_) => (3, 0), // pops ref, index, and value
             Op::HeapLoad2(_) => (2, 1),  // pops ref and index, pushes value (indirect via slot 0)
             Op::HeapStore2(_) => (3, 0), // pops ref, index, and value (indirect via slot 0)
             Op::HeapOffsetRef => (2, 1), // pops ref and offset, pushes offset ref


### PR DESCRIPTION
## Summary

- `HeapLoadDyn`/`HeapStoreDyn` に `ElemKind` パラメータを追加し、Vec/Array の typed allocation に対応する typed stride でアクセス可能にした
- `@inline` 展開時に `current_collection_elem_kind` を save/restore し、inlined Vec::set 等でも正しい stride を使用
- VM インタプリタ・JIT (x86_64/aarch64)・bytecode シリアライズをすべて対応

## Background

前回の PR (#245, #247) で `HeapLoad2`/`HeapStore2` (間接アクセス) と `HeapAllocDynSimple` に ElemKind 対応を追加したが、`HeapLoadDyn`/`HeapStoreDyn` (直接アクセス、Vec::set の `self.data[index] = value` 等) は未対応だった。これにより allocation=I64 だが store=Tagged の stride mismatch が発生していた。

## Key Design Decision

`HeapLoadDyn`/`HeapStoreDyn` の stride は `current_collection_elem_kind`（allocation 側の ElemKind）に基づいて決定する。`object_type`（型情報）ではなく allocation と同じソースを使うことで、stride/allocation の整合性を保証する。

## Test plan

- [x] `cargo fmt`
- [x] `cargo check`
- [x] `cargo test` — 全19スナップショットテスト + 4ユニットテスト通過
- [x] `cargo clippy`

🤖 Generated with [Claude Code](https://claude.ai/code)
via [Happy](https://happy.engineering)