### PR TITLE
feat: char 型を導入し string を array<char> のエイリアスに変更

### DIFF
--- a/src/compiler/codegen.rs
+++ b/src/compiler/codegen.rs
@@ -14,7 +14,7 @@ const MAX_INLINE_DEPTH: usize = 4;
 /// Determine ElemKind for a direct element type.
 fn elem_kind_for_element_type(ty: &Type) -> ElemKind {
     match ty {
-        Type::Int | Type::Bool | Type::Byte => ElemKind::I64,
+        Type::Int | Type::Bool | Type::Byte | Type::Char => ElemKind::I64,
         Type::Float => ElemKind::F64,
         Type::GenericStruct { .. } | Type::Nullable(_) | Type::Dyn => ElemKind::Ref,
         // Only treat Struct as Ref if it has fields (concrete struct).
@@ -163,7 +163,7 @@ impl Codegen {
     /// Convert the typechecker's full Type to a simplified ValueType for the VM.
     fn type_to_value_type(ty: &Type) -> ValueType {
         match ty {
-            Type::Int | Type::Byte => ValueType::I64,
+            Type::Int | Type::Byte | Type::Char => ValueType::I64,
             Type::Float => ValueType::F64,
             Type::Bool => ValueType::I32,
             Type::Struct { .. }

--- a/src/compiler/monomorphise.rs
+++ b/src/compiler/monomorphise.rs
@@ -57,6 +57,7 @@ pub fn mangle_type(ty: &Type) -> String {
         Type::Float => "float".to_string(),
         Type::Bool => "bool".to_string(),
         Type::Byte => "byte".to_string(),
+        Type::Char => "char".to_string(),
         t if t.is_string() => "string".to_string(),
         Type::Nil => "nil".to_string(),
         Type::Ptr(elem) => format!("ptr_{}", mangle_type(elem)),
@@ -804,6 +805,7 @@ fn type_to_annotation(ty: &Type) -> crate::compiler::types::TypeAnnotation {
         Type::Float => TypeAnnotation::Named("float".to_string()),
         Type::Bool => TypeAnnotation::Named("bool".to_string()),
         Type::Byte => TypeAnnotation::Named("byte".to_string()),
+        Type::Char => TypeAnnotation::Named("char".to_string()),
         t if t.is_string() => TypeAnnotation::Named("string".to_string()),
         Type::Nil => TypeAnnotation::Named("nil".to_string()),
         Type::Ptr(elem) => TypeAnnotation::Generic {

--- a/src/compiler/resolver.rs
+++ b/src/compiler/resolver.rs
@@ -922,6 +922,7 @@ impl<'a> Resolver<'a> {
                 "float" => Some(Type::Float),
                 "bool" => Some(Type::Bool),
                 "byte" => Some(Type::Byte),
+                "char" => Some(Type::Char),
                 "string" => Some(Type::string()),
                 "nil" => Some(Type::Nil),
                 _ => {

--- a/src/compiler/typechecker.rs
+++ b/src/compiler/typechecker.rs
@@ -114,6 +114,7 @@ impl Substitution {
             | Type::Float
             | Type::Bool
             | Type::Byte
+            | Type::Char
             | Type::Nil
             | Type::Any
             | Type::Dyn => ty.clone(),
@@ -294,6 +295,7 @@ impl TypeChecker {
                     "float" => Ok(Type::Float),
                     "bool" => Ok(Type::Bool),
                     "byte" => Ok(Type::Byte),
+                    "char" => Ok(Type::Char),
                     "string" => Ok(Type::string()),
                     "nil" => Ok(Type::Nil),
                     "any" => Ok(Type::Any),
@@ -416,10 +418,14 @@ impl TypeChecker {
             | (Type::Float, Type::Float)
             | (Type::Bool, Type::Bool)
             | (Type::Byte, Type::Byte)
+            | (Type::Char, Type::Char)
             | (Type::Nil, Type::Nil) => Ok(Substitution::new()),
 
             // byte and int are implicitly convertible (byte is stored as i64 at runtime)
             (Type::Byte, Type::Int) | (Type::Int, Type::Byte) => Ok(Substitution::new()),
+
+            // char and int are implicitly convertible (char is stored as i64 at runtime)
+            (Type::Char, Type::Int) | (Type::Int, Type::Char) => Ok(Substitution::new()),
 
             // Ptr<T> unification
             (Type::Ptr(a), Type::Ptr(b)) => self.unify(a, b, span),


### PR DESCRIPTION
## Summary

Closes #251

- `Type::Char` プリミティブ型を新規追加
- `string` のエイリアスを `array<byte>` から `array<char>` に変更
- `char` と `int` の暗黙的な統合（byte と同様）を追加
- 全コンパイラフェーズ（types, typechecker, codegen, monomorphise, resolver）を更新

ランタイムでは既に Unicode コードポイント単位で格納されていたため、型定義との不整合を解消する変更。`byte` 型はそのまま残す。

## Test plan

- [x] `cargo fmt` — フォーマット済み
- [x] `cargo check` — コンパイルエラーなし
- [x] `cargo test` — 全 356 テストパス
- [x] `cargo clippy` — 警告なし

🤖 Generated with [Claude Code](https://claude.ai/code)