### PR TITLE
perf: print(int) 専用 hostcall を追加しヒープ確保を排除

### DIFF
--- a/src/compiler/codegen.rs
+++ b/src/compiler/codegen.rs
@@ -1346,6 +1346,13 @@ impl Codegen {
                         self.compile_expr(&args[0], ops)?;
                         ops.push(Op::HeapSize);
                     }
+                    "__print_int" => {
+                        if args.len() != 1 {
+                            return Err("__print_int requires exactly 1 argument".to_string());
+                        }
+                        self.compile_expr(&args[0], ops)?;
+                        ops.push(Op::Hostcall(12, 1));
+                    }
                     "__hostcall" => {
                         // __hostcall(num, ...args) -> result
                         // First argument must be a compile-time constant (hostcall number)

--- a/src/compiler/resolver.rs
+++ b/src/compiler/resolver.rs
@@ -393,6 +393,8 @@ impl<'a> Resolver<'a> {
                 "argc".to_string(),
                 "argv".to_string(),
                 "args".to_string(),
+                // Specialized print builtins
+                "__print_int".to_string(),
             ],
             structs: HashMap::new(),
             primitive_methods: HashMap::new(),

--- a/src/compiler/typechecker.rs
+++ b/src/compiler/typechecker.rs
@@ -2179,6 +2179,11 @@ impl TypeChecker {
                 if callee == "print" && args.len() == 1 && type_args.is_empty() {
                     let arg_type = self.infer_expr(&mut args[0], env);
                     let resolved_arg_type = self.substitution.apply(&arg_type);
+                    // Fast path: print(int) bypasses ToString/alloc via hostcall
+                    if resolved_arg_type == Type::Int {
+                        *callee = "__print_int".to_string();
+                        return Type::Int;
+                    }
                     if matches!(
                         resolved_arg_type,
                         Type::Any | Type::Nullable(_) | Type::Var(_)

--- a/std/prelude.mc
+++ b/std/prelude.mc
@@ -15,6 +15,7 @@
 // Hostcall 9: accept(fd) -> client_fd
 // Hostcall 10: time() -> epoch_seconds
 // Hostcall 11: time_nanos() -> epoch_nanoseconds
+// Hostcall 12: print_int(n) -> 0 (write int directly to stdout with newline)
 
 // ============================================================================
 // POSIX-like Constants (as functions to avoid polluting the stack)


### PR DESCRIPTION
## Summary
- typechecker で `print(int)` を検出し `__print_int` builtin に変換
- Rust 側の `HOSTCALL_PRINT_INT` (12) で `writeln!` を直接呼び出し
- `__alloc_heap` / `__alloc_string` / `ref_to_rust_string` を全てスキップ

## 変更ファイル
- `src/vm/vm.rs`: `HOSTCALL_PRINT_INT = 12` 追加 + handler
- `src/compiler/typechecker.rs`: `print(int)` → `__print_int` リネーム
- `src/compiler/resolver.rs`: `__print_int` builtin 登録
- `src/compiler/codegen.rs`: `__print_int` → `Hostcall(12, 1)` codegen
- `std/prelude.mc`: hostcall コメント更新

## Test plan
- [x] `cargo fmt` / `cargo check` / `cargo test` / `cargo clippy` 全パス
- [x] `snapshot_basic` (file_io.mc 含む) パス
- [x] `snapshot_performance` (print_int ベンチ) パス
- [x] 手動確認: `print(42)`, `print(-1)`, `print(0)`, `print(i64::MAX)`
- [x] if-else で `print(string)` と `print(int)` が混在するケースの型チェック確認

Closes #256

🤖 Generated with [Claude Code](https://claude.ai/code)