### PR TITLE
Add YAML frontmatter metadata to moca-guide skill

### DIFF
--- a/.claude/skills/moca-guide/SKILL.md
+++ b/.claude/skills/moca-guide/SKILL.md
@@ -1,3 +1,9 @@
+---
+name: moca-guide
+description: mocaコードを書く際のリファレンス。言語仕様、構文、組み込み関数などを参照できる。
+allowed-tools: Read, Glob, Grep
+---
+
 # Moca Guide
 
 mocaコードを書く際のリファレンスとして使用するスキル。言語仕様、構文、組み込み関数などを参照できる。


### PR DESCRIPTION
## Summary
Added YAML frontmatter metadata to the moca-guide skill definition file to properly document the skill's configuration and capabilities.

## Key Changes
- Added YAML frontmatter block at the top of `SKILL.md` with:
  - `name`: Identifies the skill as "moca-guide"
  - `description`: Provides a concise Japanese description of the skill's purpose
  - `allowed-tools`: Specifies permitted tools (Read, Glob, Grep) for this skill

## Details
This metadata follows the skill definition format and enables proper skill registration and tool access control. The frontmatter allows the skill system to understand what this skill does and which tools it's authorized to use when executing tasks.

https://claude.ai/code/session_01BiPSPpWaXsc4GRPhkAYmbH