### PR TITLE
refactor(heap): Vec<u64>からVec<u8>に移行しバイトアドレッシングに統一

### DIFF
--- a/src/jit/marshal.rs
+++ b/src/jit/marshal.rs
@@ -185,8 +185,8 @@ pub struct JitCallContext {
     pub hostcall_helper:
         unsafe extern "C" fn(*mut JitCallContext, u64, u64, *const JitValue) -> JitReturn,
     /// Pointer to heap memory base (for direct heap access from JIT code)
-    /// This points to the first element of the heap's memory Vec<u64>.
-    pub heap_base: *const u64,
+    /// This points to the first byte of the heap's memory Vec<u8>.
+    pub heap_base: *const u8,
     /// Pointer to string constant cache (for direct access from JIT code)
     /// This points to the first element of VM's string_cache Vec<Option<GcRef>>.
     /// Each entry is 16 bytes: Option<GcRef> where GcRef is 8 bytes (usize).


### PR DESCRIPTION
## Summary

- Heap内部ストレージを`Vec<u64>`(ワードアドレッシング)から`Vec<u8>`(バイトアドレッシング)に移行
- GcRefのオフセットをワード単位からバイト単位に変更
- x86-64/aarch64 JITコンパイラのヒープアクセスコード生成をバイトアドレッシングに対応
- 将来のサブワード型(U8, I32)サポートや文字列効率化の基盤を整備

## 変更内容

### Phase 1: Heap本体 (`src/vm/heap.rs`)
- `read_u64`/`write_u64`/`try_read_u64`バイトアクセスヘルパーを追加
- `Heap.memory: Vec<u64>` → `Vec<u8>`に変更
- 全内部アドレッシング(next_alloc, free_list_head, GcRef)をバイト単位に統一
- Free list管理、GC mark/sweep、アロケーション、Read/Writeメソッドを更新
- `HeapObject::from_memory`を`&[u8]`対応に変更

### Phase 2: JITコンパイラ
- `JitCallContext.heap_base`を`*const u64` → `*const u8`に変更
- x86-64: `(ref + offset) << 3`パターンを`ref_bytes + offset * stride`に変更
- aarch64: 同様のアドレス計算変更を適用

## Test plan

- [x] `cargo fmt` — フォーマット済み
- [x] `cargo check` — コンパイル通過
- [x] `cargo test` — 全337 unit tests + 23 integration tests通過
- [x] `cargo clippy` — 警告なし
- [x] `snapshot_performance` — パフォーマンステスト通過

Closes #264, Closes #265

🤖 Generated with [Claude Code](https://claude.com/claude-code)