### PR TITLE
feat(heap): ElemKind::U8の実装

### DIFF
--- a/src/jit/aarch64.rs
+++ b/src/jit/aarch64.rs
@@ -357,6 +357,28 @@ impl<'a> AArch64Assembler<'a> {
         self.emit_raw(inst);
     }
 
+    /// LDRB Wt, [Xn, #imm12] (load byte with zero-extension, unsigned offset)
+    /// imm12 is NOT scaled (byte offset directly).
+    pub fn ldrb(&mut self, rt: Reg, rn: Reg, imm12: u16) {
+        // 0011 1001 01ii iiii iiii iinn nnnt tttt
+        let inst = 0x39400000
+            | (((imm12 as u32) & 0xFFF) << 10)
+            | ((rn.code() as u32) << 5)
+            | (rt.code() as u32);
+        self.emit_raw(inst);
+    }
+
+    /// STRB Wt, [Xn, #imm12] (store byte, unsigned offset)
+    /// imm12 is NOT scaled (byte offset directly).
+    pub fn strb(&mut self, rt: Reg, rn: Reg, imm12: u16) {
+        // 0011 1001 00ii iiii iiii iinn nnnt tttt
+        let inst = 0x39000000
+            | (((imm12 as u32) & 0xFFF) << 10)
+            | ((rn.code() as u32) << 5)
+            | (rt.code() as u32);
+        self.emit_raw(inst);
+    }
+
     /// LDR Xt, [Xn], #imm9 (load with post-increment)
     pub fn ldr_post(&mut self, rt: Reg, rn: Reg, imm9: i16) {
         // 1111 1000 010i iiii iiii 01nn nnnt tttt


### PR DESCRIPTION
## Summary

- Epic #263 Phase 3 (#266): 1バイト要素の配列型 `ElemKind::U8` を実装
- Phase 4 の文字列 UTF-8 化の基盤となる

## Changes

### Heap (`src/vm/heap.rs`)
- `ElemKind::U8 = 1` を有効化（`from_bits`/`from_raw` 対応）
- サイズ計算: `8 + align_up(count, 8)` バイト（8バイトアラインメント維持）
- `alloc_typed_array`: U8 対応のバイト単位ゼロ初期化
- `read_typed`/`write_typed`: バイト単位の読み書き
- `read_slot`/`write_slot`: `Value::I64(byte as i64)` として返却
- `HeapObject::from_memory`: U8 配列のパース対応
- GC mark: U8 を no-trace アームに追加
- ユニットテスト 7 件追加

### JIT Assembler
- x86-64: `movzx_rm_byte` (バイトロード+ゼロ拡張), `mov_mr_byte` (バイトストア)
- aarch64: `ldrb`, `strb`

### JIT Code Generation (両アーキテクチャ)
- `emit_heap_load_dyn`/`emit_heap_store_dyn`: U8 分岐 (stride=1)
- `emit_heap_load2`/`emit_heap_store2`: U8 分岐
- `elem_kind_to_tag`: `U8 => TAG_INT`

## Test plan

- [x] `cargo fmt` / `cargo check` / `cargo clippy` clean
- [x] 全ユニットテスト通過 (337 tests)
- [x] 全統合テスト通過 (19 tests, JIT含む)
- [x] パフォーマンステストでデグレなし

Closes #266

🤖 Generated with [Claude Code](https://claude.com/claude-code)