### PR TITLE
feat(string): 文字列の内部表現をUTF-8バイト列に移行

### DIFF
--- a/src/compiler/codegen.rs
+++ b/src/compiler/codegen.rs
@@ -14,7 +14,8 @@ const MAX_INLINE_DEPTH: usize = 4;
 /// Determine ElemKind for a direct element type.
 fn elem_kind_for_element_type(ty: &Type) -> ElemKind {
     match ty {
-        Type::Int | Type::Bool | Type::Byte | Type::Char => ElemKind::I64,
+        Type::Int | Type::Bool | Type::Byte => ElemKind::I64,
+        Type::Char => ElemKind::U8, // UTF-8 byte storage for string data
         Type::Float => ElemKind::F64,
         Type::GenericStruct { .. } | Type::Nullable(_) | Type::Dyn => ElemKind::Ref,
         // Only treat Struct as Ref if it has fields (concrete struct).

--- a/src/compiler/desugar.rs
+++ b/src/compiler/desugar.rs
@@ -1168,7 +1168,7 @@ impl Desugar {
 
         // Phase 2: let __interp_buf = __alloc_heap(__interp_total);
         let buf_var = self.fresh_var();
-        let ptr_int = Type::Ptr(Box::new(Type::Int));
+        let ptr_int = Type::Ptr(Box::new(Type::Char));
         stmts.push(Statement::Let {
             name: buf_var.clone(),
             type_annotation: None,

--- a/std/prelude.mc
+++ b/std/prelude.mc
@@ -186,7 +186,7 @@ fun _int_digit_count(n: int) -> int {
 //   q = (val * 3435973837) >> 35  (Granlund-Montgomery style)
 //   r = val - q * 10
 @inline
-fun _int_write_to(buf: ptr<int>, off: int, n: int, dcount: int) -> int {
+fun _int_write_to(buf: ptr<char>, off: int, n: int, dcount: int) -> int {
     if n == 0 {
         buf[off] = 48;
         return off + 1;
@@ -236,7 +236,7 @@ fun _int_write_to(buf: ptr<int>, off: int, n: int, dcount: int) -> int {
 
 // Copy string data into buf at offset, return new offset.
 @inline
-fun _str_copy_to(buf: ptr<int>, off: int, s: string) -> int {
+fun _str_copy_to(buf: ptr<char>, off: int, s: string) -> int {
     let sptr = s.data;
     let slen = s.len;
     let j = 0;
@@ -258,7 +258,7 @@ fun _bool_str_len(b: bool) -> int {
 
 // Write "true" or "false" into buf at offset, return new offset.
 @inline
-fun _bool_write_to(buf: ptr<int>, off: int, b: bool) -> int {
+fun _bool_write_to(buf: ptr<char>, off: int, b: bool) -> int {
     if b {
         buf[off] = 116;
         buf[off + 1] = 114;
@@ -588,7 +588,7 @@ fun _ryu_formatted_length(mantissa: int, exponent: int, length: int, kk: int) ->
     return kk + 2;
 }
 
-fun _ryu_write_to(buf: ptr<int>, off: int, mantissa: int, exponent: int, length: int, kk: int, sign: int) -> int {
+fun _ryu_write_to(buf: ptr<char>, off: int, mantissa: int, exponent: int, length: int, kk: int, sign: int) -> int {
     let pos = off;
     if sign != 0 { buf[pos] = 45; pos = pos + 1; }
     if kk <= 0 {
@@ -649,7 +649,7 @@ fun _float_digit_count(f: float) -> int {
     return sign + _ryu_formatted_length(mantissa, exponent, length, kk);
 }
 
-fun _float_write_to(buf: ptr<int>, off: int, f: float) -> int {
+fun _float_write_to(buf: ptr<char>, off: int, f: float) -> int {
     let bits = __float_bits(f);
     let sign = _ushr(bits, 63);
     let ieee_exp = _ushr(bits, 52) & 2047;

--- a/tests/snapshots/basic/string_concat.stdout
+++ b/tests/snapshots/basic/string_concat.stdout
@@ -2,4 +2,4 @@ Hello World!
 test
 5
 0
-5
+15


### PR DESCRIPTION
## Summary

Closes #267

文字列の内部データを `ElemKind::I64`（1文字=8byte）から `ElemKind::U8`（UTF-8バイト列）に変更し、メモリ効率を大幅に改善。

- ASCII文字列: 8倍の改善（8 bytes/char → 1 byte/char）
- マルチバイト文字列: 約2.7倍の改善（8 bytes/char → 3 bytes/char）

### 変更内容

- `heap.rs`: `alloc_string` を UTF-8 バイト列格納に変更、`slots_to_string` を UTF-8 デコードに変更
- `vm.rs`: `value_to_string` の文字列検出を ElemKind ベースに変更（ヒューリスティックから確実な判定へ）
- `prelude.mc`: バッファ型を `ptr<int>` から `ptr<char>` に変更（`_int_write_to`, `_float_write_to`, `_bool_write_to`, `_ryu_write_to`, `_str_copy_to`）
- `desugar.rs`: 文字列補間バッファ型を `ptr<char>` に変更
- `codegen.rs`: `Type::Char` を `ElemKind::U8` にマッピング

### 破壊的変更

- `len()` はバイト長を返す（Go/Rust スタイル）
- `str[i]` はバイト単位アクセス

## Test plan

- [x] `cargo test` 全テスト通過（19/19 snapshot tests, 全ユニットテスト）
- [x] `cargo clippy` 警告なし
- [x] `text_counting` パフォーマンステスト通過（ElemKind不整合の解消）
- [x] 文字列補間、連結、比較、インデックスアクセスの動作確認

🤖 Generated with [Claude Code](https://claude.ai/code)