### PR TITLE
fix(vm): VReg境界チェックとHeapLoadエラーメッセージを改善 (#273)

### DIFF
--- a/tests/snapshots/basic/recursive_many_locals.mc
+++ b/tests/snapshots/basic/recursive_many_locals.mc
@@ -1,0 +1,30 @@
+// Regression test for #273: recursive calls with many local variables
+// should not cause stack corruption or "expected reference" errors.
+// This test exercises _any_to_string's recursive path through struct formatting.
+
+struct Inner {
+    value: int,
+}
+
+struct Outer {
+    inner: Inner,
+}
+
+struct DeepA {
+    child: Outer,
+}
+
+struct DeepB {
+    child: DeepA,
+}
+
+let i = Inner { value: 42 };
+let o = Outer { inner: i };
+let da = DeepA { child: o };
+let db = DeepB { child: da };
+
+// Recursive _any_to_string through multiple levels of struct nesting
+print(i);
+print(o);
+print(da);
+print(db);

--- a/tests/snapshots/basic/recursive_many_locals.stdout
+++ b/tests/snapshots/basic/recursive_many_locals.stdout
@@ -1,0 +1,4 @@
+Inner { value: 42 }
+Outer { inner: Inner { value: 42 } }
+DeepA { child: Outer { inner: Inner { value: 42 } } }
+DeepB { child: DeepA { child: Outer { inner: Inner { value: 42 } } } }


### PR DESCRIPTION
## Summary
- `_any_to_string` の再帰呼び出し時に発生しうるスタック破壊を防止するための防御的チェックを追加（#273）
- MicroOp変換後にすべてのVRegインデックスが割り当て済みレジスタファイル範囲内であることを `debug_assert` で検証
- StackPopハンドラに `temps_count` 過少検出用の `debug_assert` を追加
- HeapLoadエラーメッセージにVRegインデックスと実際の値を含めるよう改善
- 深いネストの構造体を使ったリグレッションテスト `recursive_many_locals` を追加

## Test plan
- [x] `cargo test` 全テスト通過確認
- [x] `cargo clippy` lint通過確認
- [x] `recursive_many_locals.mc` で4段ネストの構造体printが正常動作することを確認

Closes #273

🤖 Generated with [Claude Code](https://claude.ai/code)
via [Happy](https://happy.engineering)