### PR TITLE
test(gc,codegen): GC / codegen のテストカバレッジ強化

### DIFF
--- a/src/compiler/codegen.rs
+++ b/src/compiler/codegen.rs
@@ -2180,4 +2180,517 @@ mod tests {
         assert_eq!(chunk.functions.len(), 1);
         assert_eq!(chunk.functions[0].name, "foo");
     }
+
+    // =========================================================================
+    // Expression Code Generation Tests
+    // =========================================================================
+
+    #[test]
+    fn test_bool_literals() {
+        let chunk = compile("__typeof(true);").unwrap();
+        assert!(chunk.main.code.contains(&Op::I32Const(1)));
+
+        let chunk = compile("__typeof(false);").unwrap();
+        assert!(chunk.main.code.contains(&Op::I32Const(0)));
+    }
+
+    #[test]
+    fn test_float_literal() {
+        let chunk = compile("__typeof(3.14);").unwrap();
+        assert!(chunk.main.code.contains(&Op::F64Const(3.14)));
+    }
+
+    #[test]
+    fn test_nil_literal() {
+        let chunk = compile("__typeof(nil);").unwrap();
+        assert!(chunk.main.code.contains(&Op::RefNull));
+    }
+
+    #[test]
+    fn test_string_literal() {
+        let chunk = compile("__typeof(\"hello\");").unwrap();
+        assert!(chunk.main.code.contains(&Op::StringConst(0)));
+        assert_eq!(chunk.strings[0], "hello");
+    }
+
+    #[test]
+    fn test_multiple_strings() {
+        let chunk = compile("__typeof(\"foo\"); __typeof(\"bar\");").unwrap();
+        assert!(chunk.main.code.contains(&Op::StringConst(0)));
+        assert!(chunk.main.code.contains(&Op::StringConst(1)));
+        assert_eq!(chunk.strings[0], "foo");
+        assert_eq!(chunk.strings[1], "bar");
+    }
+
+    #[test]
+    fn test_unary_negation() {
+        let chunk = compile("__typeof(-42);").unwrap();
+        assert!(chunk.main.code.contains(&Op::I64Const(42)));
+        assert!(chunk.main.code.contains(&Op::I64Neg));
+    }
+
+    #[test]
+    fn test_unary_not() {
+        let chunk = compile("__typeof(!true);").unwrap();
+        assert!(chunk.main.code.contains(&Op::I32Eqz));
+    }
+
+    #[test]
+    fn test_subtraction() {
+        let chunk = compile("__typeof(10 - 3);").unwrap();
+        assert!(chunk.main.code.contains(&Op::I64Sub));
+    }
+
+    #[test]
+    fn test_multiplication() {
+        let chunk = compile("__typeof(4 * 5);").unwrap();
+        assert!(chunk.main.code.contains(&Op::I64Mul));
+    }
+
+    #[test]
+    fn test_division() {
+        let chunk = compile("__typeof(10 / 2);").unwrap();
+        assert!(chunk.main.code.contains(&Op::I64DivS));
+    }
+
+    #[test]
+    fn test_modulo() {
+        let chunk = compile("__typeof(10 % 3);").unwrap();
+        assert!(chunk.main.code.contains(&Op::I64RemS));
+    }
+
+    #[test]
+    fn test_comparison_operators() {
+        let chunk = compile("__typeof(1 < 2);").unwrap();
+        assert!(chunk.main.code.contains(&Op::I64LtS));
+
+        let chunk = compile("__typeof(1 <= 2);").unwrap();
+        assert!(chunk.main.code.contains(&Op::I64LeS));
+
+        let chunk = compile("__typeof(1 > 2);").unwrap();
+        assert!(chunk.main.code.contains(&Op::I64GtS));
+
+        let chunk = compile("__typeof(1 >= 2);").unwrap();
+        assert!(chunk.main.code.contains(&Op::I64GeS));
+
+        let chunk = compile("__typeof(1 == 2);").unwrap();
+        assert!(chunk.main.code.contains(&Op::I64Eq));
+
+        let chunk = compile("__typeof(1 != 2);").unwrap();
+        assert!(chunk.main.code.contains(&Op::I64Ne));
+    }
+
+    #[test]
+    fn test_float_arithmetic() {
+        let chunk = compile("__typeof(1.0 + 2.0);").unwrap();
+        assert!(chunk.main.code.contains(&Op::F64Add));
+
+        let chunk = compile("__typeof(1.0 - 2.0);").unwrap();
+        assert!(chunk.main.code.contains(&Op::F64Sub));
+
+        let chunk = compile("__typeof(1.0 * 2.0);").unwrap();
+        assert!(chunk.main.code.contains(&Op::F64Mul));
+
+        let chunk = compile("__typeof(1.0 / 2.0);").unwrap();
+        assert!(chunk.main.code.contains(&Op::F64Div));
+    }
+
+    #[test]
+    fn test_float_negation() {
+        let chunk = compile("__typeof(-1.0);").unwrap();
+        assert!(chunk.main.code.contains(&Op::F64Neg));
+    }
+
+    #[test]
+    fn test_float_comparison() {
+        let chunk = compile("__typeof(1.0 < 2.0);").unwrap();
+        assert!(chunk.main.code.contains(&Op::F64Lt));
+
+        let chunk = compile("__typeof(1.0 == 2.0);").unwrap();
+        assert!(chunk.main.code.contains(&Op::F64Eq));
+    }
+
+    #[test]
+    fn test_bitwise_operators() {
+        let chunk = compile("__typeof(5 & 3);").unwrap();
+        assert!(chunk.main.code.contains(&Op::I64And));
+
+        let chunk = compile("__typeof(5 | 3);").unwrap();
+        assert!(chunk.main.code.contains(&Op::I64Or));
+
+        let chunk = compile("__typeof(5 ^ 3);").unwrap();
+        assert!(chunk.main.code.contains(&Op::I64Xor));
+
+        let chunk = compile("__typeof(1 << 3);").unwrap();
+        assert!(chunk.main.code.contains(&Op::I64Shl));
+
+        let chunk = compile("__typeof(8 >> 2);").unwrap();
+        assert!(chunk.main.code.contains(&Op::I64ShrS));
+    }
+
+    #[test]
+    fn test_logical_and_short_circuit() {
+        let chunk = compile("__typeof(true && false);").unwrap();
+        // && uses Dup + BrIfFalse for short-circuit
+        assert!(chunk.main.code.contains(&Op::Dup));
+        assert!(
+            chunk
+                .main
+                .code
+                .iter()
+                .any(|op| matches!(op, Op::BrIfFalse(_)))
+        );
+    }
+
+    #[test]
+    fn test_logical_or_short_circuit() {
+        let chunk = compile("__typeof(true || false);").unwrap();
+        // || uses Dup + BrIf for short-circuit
+        assert!(chunk.main.code.contains(&Op::Dup));
+        assert!(chunk.main.code.iter().any(|op| matches!(op, Op::BrIf(_))));
+    }
+
+    #[test]
+    fn test_array_literal() {
+        let chunk = compile("__typeof([1, 2, 3]);").unwrap();
+        // Array creates data array + struct
+        assert!(chunk.main.code.contains(&Op::HeapAlloc(3))); // data array
+        assert!(chunk.main.code.contains(&Op::HeapAlloc(2))); // Array struct [ptr, len]
+        assert!(chunk.main.code.contains(&Op::I64Const(3))); // len = 3
+    }
+
+    #[test]
+    fn test_heap_size_builtin() {
+        let chunk = compile("__heap_size([1]);").unwrap();
+        assert!(chunk.main.code.contains(&Op::HeapSize));
+    }
+
+    // =========================================================================
+    // Statement Code Generation Tests
+    // =========================================================================
+
+    #[test]
+    fn test_let_statement() {
+        let chunk = compile("let x = 42;").unwrap();
+        assert!(chunk.main.code.contains(&Op::I64Const(42)));
+        assert!(
+            chunk
+                .main
+                .code
+                .iter()
+                .any(|op| matches!(op, Op::LocalSet(_)))
+        );
+    }
+
+    #[test]
+    fn test_assignment() {
+        let chunk = compile("let x = 1; x = 2;").unwrap();
+        assert!(chunk.main.code.contains(&Op::I64Const(1)));
+        assert!(chunk.main.code.contains(&Op::I64Const(2)));
+        // Two LocalSet operations (init + assign)
+        let set_count = chunk
+            .main
+            .code
+            .iter()
+            .filter(|op| matches!(op, Op::LocalSet(_)))
+            .count();
+        assert_eq!(set_count, 2);
+    }
+
+    #[test]
+    fn test_if_statement() {
+        let chunk = compile("let x = 1; if true { x = 2; }").unwrap();
+        assert!(
+            chunk
+                .main
+                .code
+                .iter()
+                .any(|op| matches!(op, Op::BrIfFalse(_)))
+        );
+    }
+
+    #[test]
+    fn test_if_else_statement() {
+        let chunk = compile("let x = 0; if true { x = 1; } else { x = 2; }").unwrap();
+        // Should have BrIfFalse (jump to else) and Jmp (jump over else)
+        assert!(
+            chunk
+                .main
+                .code
+                .iter()
+                .any(|op| matches!(op, Op::BrIfFalse(_)))
+        );
+        assert!(chunk.main.code.iter().any(|op| matches!(op, Op::Jmp(_))));
+    }
+
+    #[test]
+    fn test_while_loop() {
+        let chunk = compile("let i = 0; while i < 10 { i = i + 1; }").unwrap();
+        assert!(chunk.main.code.contains(&Op::I64LtS));
+        assert!(
+            chunk
+                .main
+                .code
+                .iter()
+                .any(|op| matches!(op, Op::BrIfFalse(_)))
+        );
+        assert!(chunk.main.code.iter().any(|op| matches!(op, Op::Jmp(_))));
+    }
+
+    #[test]
+    fn test_return_statement() {
+        let chunk = compile("fun foo() -> int { return 42; } __typeof(foo());").unwrap();
+        assert!(chunk.functions[0].code.contains(&Op::I64Const(42)));
+        assert!(chunk.functions[0].code.contains(&Op::Ret));
+    }
+
+    #[test]
+    fn test_return_void() {
+        let chunk = compile("fun foo() { return; } foo();").unwrap();
+        // Void return pushes RefNull
+        assert!(chunk.functions[0].code.contains(&Op::RefNull));
+        assert!(chunk.functions[0].code.contains(&Op::Ret));
+    }
+
+    #[test]
+    fn test_throw_statement() {
+        let chunk = compile("fun foo() { throw 1; } foo();").unwrap();
+        assert!(chunk.functions[0].code.contains(&Op::Throw));
+    }
+
+    #[test]
+    fn test_try_catch() {
+        let chunk = compile("try { throw 1; } catch e { __typeof(e); }").unwrap();
+        assert!(
+            chunk
+                .main
+                .code
+                .iter()
+                .any(|op| matches!(op, Op::TryBegin(_)))
+        );
+        assert!(chunk.main.code.contains(&Op::TryEnd));
+    }
+
+    #[test]
+    fn test_break_continue() {
+        let chunk =
+            compile("let i = 0; while i < 10 { if i == 5 { break; } i = i + 1; continue; }")
+                .unwrap();
+        // break and continue generate Jmp instructions
+        let jmp_count = chunk
+            .main
+            .code
+            .iter()
+            .filter(|op| matches!(op, Op::Jmp(_)))
+            .count();
+        // At least 3 Jmps: loop back, break, continue
+        assert!(jmp_count >= 3);
+    }
+
+    #[test]
+    fn test_expr_statement_drops_result() {
+        let chunk = compile("42;").unwrap();
+        assert!(chunk.main.code.contains(&Op::I64Const(42)));
+        assert!(chunk.main.code.contains(&Op::Drop));
+    }
+
+    #[test]
+    fn test_struct_literal() {
+        let chunk =
+            compile("struct Point { x: int, y: int } let p = Point { x: 1, y: 2 };").unwrap();
+        assert!(chunk.main.code.contains(&Op::HeapAlloc(2)));
+    }
+
+    // =========================================================================
+    // Edge Cases
+    // =========================================================================
+
+    #[test]
+    fn test_deeply_nested_if() {
+        let source = "
+            let x = 0;
+            if true {
+                if true {
+                    if true {
+                        if true {
+                            if true {
+                                x = 42;
+                            }
+                        }
+                    }
+                }
+            }
+        ";
+        let chunk = compile(source).unwrap();
+        assert!(chunk.main.code.contains(&Op::I64Const(42)));
+        // Should have 5 BrIfFalse instructions
+        let br_count = chunk
+            .main
+            .code
+            .iter()
+            .filter(|op| matches!(op, Op::BrIfFalse(_)))
+            .count();
+        assert_eq!(br_count, 5);
+    }
+
+    #[test]
+    fn test_nested_while_loops() {
+        let source = "
+            let i = 0;
+            while i < 10 {
+                let j = 0;
+                while j < 10 {
+                    j = j + 1;
+                }
+                i = i + 1;
+            }
+        ";
+        let chunk = compile(source).unwrap();
+        // Two BrIfFalse (one per while loop)
+        let br_count = chunk
+            .main
+            .code
+            .iter()
+            .filter(|op| matches!(op, Op::BrIfFalse(_)))
+            .count();
+        assert_eq!(br_count, 2);
+        // Two Jmp back to loop start
+        let jmp_count = chunk
+            .main
+            .code
+            .iter()
+            .filter(|op| matches!(op, Op::Jmp(_)))
+            .count();
+        assert_eq!(jmp_count, 2);
+    }
+
+    #[test]
+    fn test_large_function_many_locals() {
+        let mut source = String::new();
+        source.push_str("fun big() -> int {\n");
+        for i in 0..50 {
+            source.push_str(&format!("    let v{} = {};\n", i, i));
+        }
+        // Sum them up in pairs to produce a result
+        source.push_str("    return v0 + v49;\n");
+        source.push_str("}\n");
+        source.push_str("__typeof(big());\n");
+
+        let chunk = compile(&source).unwrap();
+        assert_eq!(chunk.functions.len(), 1);
+        assert_eq!(chunk.functions[0].name, "big");
+        // Should have 50 local variables in the function
+        assert!(chunk.functions[0].locals_count >= 50);
+    }
+
+    #[test]
+    fn test_multiple_functions() {
+        let source = "
+            fun add(a: int, b: int) -> int { return a + b; }
+            fun sub(a: int, b: int) -> int { return a - b; }
+            fun mul(a: int, b: int) -> int { return a * b; }
+            __typeof(add(1, 2));
+            __typeof(sub(3, 1));
+            __typeof(mul(2, 3));
+        ";
+        let chunk = compile(source).unwrap();
+        assert_eq!(chunk.functions.len(), 3);
+        assert_eq!(chunk.functions[0].name, "add");
+        assert_eq!(chunk.functions[1].name, "sub");
+        assert_eq!(chunk.functions[2].name, "mul");
+    }
+
+    #[test]
+    fn test_recursive_function() {
+        let source = "
+            fun fib(n: int) -> int {
+                if n <= 1 { return n; }
+                return fib(n - 1) + fib(n - 2);
+            }
+            __typeof(fib(10));
+        ";
+        let chunk = compile(source).unwrap();
+        assert_eq!(chunk.functions.len(), 1);
+        assert_eq!(chunk.functions[0].name, "fib");
+        // fib calls itself: should have two Call instructions
+        let call_count = chunk.functions[0]
+            .code
+            .iter()
+            .filter(|op| matches!(op, Op::Call(0, 1)))
+            .count();
+        assert_eq!(call_count, 2);
+    }
+
+    #[test]
+    fn test_deeply_nested_expressions() {
+        // Test deeply nested arithmetic: ((((1 + 2) + 3) + 4) + 5)
+        let source = "__typeof(((((1 + 2) + 3) + 4) + 5));";
+        let chunk = compile(source).unwrap();
+        let add_count = chunk
+            .main
+            .code
+            .iter()
+            .filter(|op| matches!(op, Op::I64Add))
+            .count();
+        assert_eq!(add_count, 4);
+    }
+
+    #[test]
+    fn test_complex_expression() {
+        let source = "__typeof((1 + 2) * (3 - 4) + 5);";
+        let chunk = compile(source).unwrap();
+        assert!(chunk.main.code.contains(&Op::I64Add));
+        assert!(chunk.main.code.contains(&Op::I64Mul));
+        assert!(chunk.main.code.contains(&Op::I64Sub));
+    }
+
+    #[test]
+    fn test_function_with_multiple_params() {
+        let source = "
+            fun f(a: int, b: int, c: int, d: int) -> int {
+                return a + b + c + d;
+            }
+            __typeof(f(1, 2, 3, 4));
+        ";
+        let chunk = compile(source).unwrap();
+        assert_eq!(chunk.functions[0].name, "f");
+        assert_eq!(chunk.functions[0].arity, 4);
+    }
+
+    #[test]
+    fn test_empty_function() {
+        let source = "fun noop() { } noop();";
+        let chunk = compile(source).unwrap();
+        assert_eq!(chunk.functions.len(), 1);
+        assert_eq!(chunk.functions[0].name, "noop");
+    }
+
+    #[test]
+    fn test_if_else_with_nested_loops() {
+        let source = "
+            let result = 0;
+            if true {
+                let i = 0;
+                while i < 5 {
+                    result = result + i;
+                    i = i + 1;
+                }
+            } else {
+                let j = 0;
+                while j < 3 {
+                    result = result - j;
+                    j = j + 1;
+                }
+            }
+        ";
+        let chunk = compile(source).unwrap();
+        // Should have 2 BrIfFalse (1 for if, 2 for while loops) and multiple Jmps
+        let br_count = chunk
+            .main
+            .code
+            .iter()
+            .filter(|op| matches!(op, Op::BrIfFalse(_)))
+            .count();
+        assert!(br_count >= 2);
+    }
 }

--- a/src/vm/heap.rs
+++ b/src/vm/heap.rs
@@ -1592,4 +1592,351 @@ mod tests {
         assert_eq!(heap.read_typed(u8_arr, 0), Some(0xAB));
         assert_eq!(heap.read_typed(i64_arr, 0), Some(12345));
     }
+
+    // =========================================================================
+    // Mass Allocation & GC Trigger Tests
+    // =========================================================================
+
+    #[test]
+    fn test_mass_allocation_gc_trigger() {
+        let mut heap = Heap::new_with_config(None, true);
+
+        // Allocate many objects, keeping only a few as roots
+        let mut roots = Vec::new();
+        for i in 0..500 {
+            let r = heap.alloc_slots(vec![Value::I64(i)]).unwrap();
+            // Keep every 50th object
+            if i % 50 == 0 {
+                roots.push(Value::Ref(r));
+            }
+        }
+
+        let before_gc = heap.object_count();
+        assert_eq!(before_gc, 500);
+
+        // Trigger GC manually
+        let root_values: Vec<Value> = roots.clone();
+        heap.collect(&root_values);
+
+        // Only the kept roots should survive (10 objects: 0, 50, 100, ..., 450)
+        assert_eq!(heap.object_count(), 10);
+
+        // All surviving objects should have correct values
+        for (idx, root) in roots.iter().enumerate() {
+            if let Value::Ref(r) = root {
+                let obj = heap.get(*r).unwrap();
+                assert_eq!(obj.slots[0], Value::I64((idx * 50) as i64));
+            }
+        }
+    }
+
+    #[test]
+    fn test_mass_allocation_with_gc_threshold() {
+        // Use a small heap with GC enabled to force GC during allocation
+        let mut heap = Heap::new_with_config(None, true);
+        // Lower the GC threshold to trigger sooner
+        heap.gc_threshold = 1024;
+
+        let mut live_refs = Vec::new();
+        for i in 0..200 {
+            let r = heap
+                .alloc_slots(vec![Value::I64(i), Value::I64(i * 2)])
+                .unwrap();
+            // Keep only the last 10 objects alive
+            if i >= 190 {
+                live_refs.push(r);
+            }
+
+            // Simulate what the VM does: check and collect
+            if heap.should_gc() {
+                let roots: Vec<Value> = live_refs.iter().map(|r| Value::Ref(*r)).collect();
+                heap.collect(&roots);
+            }
+        }
+
+        // All surviving refs should be valid
+        for (idx, r) in live_refs.iter().enumerate() {
+            let i = (190 + idx) as i64;
+            let obj = heap.get(*r).unwrap();
+            assert_eq!(obj.slots[0], Value::I64(i));
+            assert_eq!(obj.slots[1], Value::I64(i * 2));
+        }
+    }
+
+    #[test]
+    fn test_mass_allocation_mixed_types() {
+        let mut heap = Heap::new();
+
+        let mut roots = Vec::new();
+        for i in 0..100 {
+            match i % 3 {
+                0 => {
+                    let r = heap.alloc_slots(vec![Value::I64(i)]).unwrap();
+                    if i % 30 == 0 {
+                        roots.push(Value::Ref(r));
+                    }
+                }
+                1 => {
+                    let r = heap.alloc_typed_array(3, ElemKind::I64).unwrap();
+                    heap.write_typed(r, 0, i as u64).unwrap();
+                    if i % 31 == 0 {
+                        roots.push(Value::Ref(r));
+                    }
+                }
+                _ => {
+                    let r = heap.alloc_typed_array(5, ElemKind::U8).unwrap();
+                    heap.write_typed(r, 0, (i % 256) as u64).unwrap();
+                    if i % 32 == 0 {
+                        roots.push(Value::Ref(r));
+                    }
+                }
+            }
+        }
+
+        let before = heap.object_count();
+        assert_eq!(before, 100);
+
+        heap.collect(&roots);
+
+        // Only root objects should survive
+        assert_eq!(heap.object_count(), roots.len());
+    }
+
+    // =========================================================================
+    // Circular Reference Tests
+    // =========================================================================
+
+    #[test]
+    fn test_gc_circular_reference_two_objects() {
+        let mut heap = Heap::new();
+
+        // Create two objects that reference each other
+        let a = heap.alloc_slots(vec![Value::Null]).unwrap();
+        let b = heap.alloc_slots(vec![Value::Ref(a)]).unwrap();
+        // Complete the cycle: a -> b
+        heap.write_slot(a, 0, Value::Ref(b)).unwrap();
+
+        // Verify the cycle exists
+        assert_eq!(heap.read_slot(a, 0), Some(Value::Ref(b)));
+        assert_eq!(heap.read_slot(b, 0), Some(Value::Ref(a)));
+
+        // GC with a as root: both should survive (b is reachable from a)
+        heap.collect(&[Value::Ref(a)]);
+        assert_eq!(heap.object_count(), 2);
+        assert_eq!(heap.read_slot(a, 0), Some(Value::Ref(b)));
+        assert_eq!(heap.read_slot(b, 0), Some(Value::Ref(a)));
+    }
+
+    #[test]
+    fn test_gc_circular_reference_unreachable() {
+        let mut heap = Heap::new();
+
+        // Create a cycle that is NOT reachable from roots
+        let a = heap.alloc_slots(vec![Value::Null]).unwrap();
+        let b = heap.alloc_slots(vec![Value::Ref(a)]).unwrap();
+        heap.write_slot(a, 0, Value::Ref(b)).unwrap();
+
+        // Create a separate live object
+        let live = heap.alloc_slots(vec![Value::I64(42)]).unwrap();
+
+        assert_eq!(heap.object_count(), 3);
+
+        // GC with only 'live' as root: the cycle should be collected
+        heap.collect(&[Value::Ref(live)]);
+        assert_eq!(heap.object_count(), 1);
+        assert_eq!(heap.get(live).unwrap().slots[0], Value::I64(42));
+    }
+
+    #[test]
+    fn test_gc_circular_reference_three_objects() {
+        let mut heap = Heap::new();
+
+        // Create a 3-node cycle: a -> b -> c -> a
+        let a = heap.alloc_slots(vec![Value::Null]).unwrap();
+        let b = heap.alloc_slots(vec![Value::Null]).unwrap();
+        let c = heap.alloc_slots(vec![Value::Ref(a)]).unwrap();
+        heap.write_slot(a, 0, Value::Ref(b)).unwrap();
+        heap.write_slot(b, 0, Value::Ref(c)).unwrap();
+
+        // GC with a as root: all three should survive
+        heap.collect(&[Value::Ref(a)]);
+        assert_eq!(heap.object_count(), 3);
+
+        // Verify cycle is intact
+        assert_eq!(heap.read_slot(a, 0), Some(Value::Ref(b)));
+        assert_eq!(heap.read_slot(b, 0), Some(Value::Ref(c)));
+        assert_eq!(heap.read_slot(c, 0), Some(Value::Ref(a)));
+    }
+
+    #[test]
+    fn test_gc_circular_reference_via_typed_ref_array() {
+        let mut heap = Heap::new();
+
+        // Create a cycle using typed Ref arrays
+        let a = heap.alloc_typed_array(1, ElemKind::Ref).unwrap();
+        let b = heap.alloc_typed_array(1, ElemKind::Ref).unwrap();
+
+        // a -> b -> a
+        heap.write_typed(a, 0, b.index as u64).unwrap();
+        heap.write_typed(b, 0, a.index as u64).unwrap();
+
+        // With a as root, both survive
+        heap.collect(&[Value::Ref(a)]);
+        assert_eq!(heap.object_count(), 2);
+
+        // Without any root, both are collected
+        heap.collect(&[]);
+        assert_eq!(heap.object_count(), 0);
+    }
+
+    #[test]
+    fn test_gc_self_referencing_object() {
+        let mut heap = Heap::new();
+
+        // Create an object that references itself
+        let a = heap.alloc_slots(vec![Value::Null]).unwrap();
+        heap.write_slot(a, 0, Value::Ref(a)).unwrap();
+
+        assert_eq!(heap.read_slot(a, 0), Some(Value::Ref(a)));
+
+        // GC should handle self-reference without infinite loop
+        heap.collect(&[Value::Ref(a)]);
+        assert_eq!(heap.object_count(), 1);
+        assert_eq!(heap.read_slot(a, 0), Some(Value::Ref(a)));
+    }
+
+    // =========================================================================
+    // Heap Integrity After GC Tests
+    // =========================================================================
+
+    #[test]
+    fn test_heap_integrity_after_gc() {
+        let mut heap = Heap::new();
+
+        // Create a mix of live and dead objects
+        let live1 = heap
+            .alloc_slots(vec![Value::I64(111), Value::I64(222)])
+            .unwrap();
+        let _dead1 = heap.alloc_slots(vec![Value::I64(999)]).unwrap();
+        let live2 = heap.alloc_string("hello".to_string()).unwrap();
+        let _dead2 = heap
+            .alloc_slots(vec![Value::I64(888), Value::I64(777)])
+            .unwrap();
+        let live3 = heap.alloc_typed_array(3, ElemKind::I64).unwrap();
+        heap.write_typed(live3, 0, 10).unwrap();
+        heap.write_typed(live3, 1, 20).unwrap();
+        heap.write_typed(live3, 2, 30).unwrap();
+
+        heap.collect(&[Value::Ref(live1), Value::Ref(live2), Value::Ref(live3)]);
+
+        // Verify all live objects retain their data
+        let obj1 = heap.get(live1).unwrap();
+        assert_eq!(obj1.slots[0], Value::I64(111));
+        assert_eq!(obj1.slots[1], Value::I64(222));
+
+        let obj2 = heap.get(live2).unwrap();
+        assert_eq!(obj2.slots.len(), 2); // [ptr, len]
+        assert_eq!(obj2.slots[1], Value::I64(5)); // len = 5
+
+        assert_eq!(heap.read_typed(live3, 0), Some(10));
+        assert_eq!(heap.read_typed(live3, 1), Some(20));
+        assert_eq!(heap.read_typed(live3, 2), Some(30));
+
+        assert_eq!(heap.object_count(), 3 + 1); // +1 for string data array
+    }
+
+    #[test]
+    fn test_heap_integrity_after_multiple_gc_cycles() {
+        let mut heap = Heap::new();
+
+        // Cycle 1: Create objects, GC, verify
+        let r1 = heap
+            .alloc_slots(vec![Value::I64(1), Value::I64(2)])
+            .unwrap();
+        for i in 0..20 {
+            let _ = heap.alloc_slots(vec![Value::I64(i + 100)]).unwrap();
+        }
+        heap.collect(&[Value::Ref(r1)]);
+        assert_eq!(heap.object_count(), 1);
+        assert_eq!(heap.get(r1).unwrap().slots[0], Value::I64(1));
+
+        // Cycle 2: Allocate more (should reuse freed memory), GC again
+        let r2 = heap.alloc_slots(vec![Value::I64(3)]).unwrap();
+        for i in 0..30 {
+            let _ = heap.alloc_slots(vec![Value::I64(i + 200)]).unwrap();
+        }
+        heap.collect(&[Value::Ref(r1), Value::Ref(r2)]);
+        assert_eq!(heap.object_count(), 2);
+        assert_eq!(heap.get(r1).unwrap().slots[0], Value::I64(1));
+        assert_eq!(heap.get(r2).unwrap().slots[0], Value::I64(3));
+
+        // Cycle 3: Remove r1, keep r2 and add r3
+        let r3 = heap
+            .alloc_slots(vec![Value::I64(5), Value::I64(6)])
+            .unwrap();
+        heap.collect(&[Value::Ref(r2), Value::Ref(r3)]);
+        assert_eq!(heap.object_count(), 2);
+        assert_eq!(heap.get(r2).unwrap().slots[0], Value::I64(3));
+        assert_eq!(heap.get(r3).unwrap().slots[0], Value::I64(5));
+        assert_eq!(heap.get(r3).unwrap().slots[1], Value::I64(6));
+    }
+
+    #[test]
+    fn test_heap_integrity_object_graph_after_gc() {
+        let mut heap = Heap::new();
+
+        // Build a tree: root -> [child1, child2], child1 -> [leaf]
+        let leaf = heap.alloc_slots(vec![Value::I64(42)]).unwrap();
+        let child1 = heap.alloc_slots(vec![Value::Ref(leaf)]).unwrap();
+        let child2 = heap.alloc_slots(vec![Value::I64(99)]).unwrap();
+        let root = heap
+            .alloc_slots(vec![Value::Ref(child1), Value::Ref(child2)])
+            .unwrap();
+
+        // Also create garbage
+        for _ in 0..10 {
+            let _ = heap.alloc_slots(vec![Value::I64(0)]).unwrap();
+        }
+
+        heap.collect(&[Value::Ref(root)]);
+
+        // Tree should be intact: 4 objects
+        assert_eq!(heap.object_count(), 4);
+
+        // Verify full traversal
+        let root_obj = heap.get(root).unwrap();
+        let c1_ref = root_obj.slots[0].as_ref().unwrap();
+        let c2_ref = root_obj.slots[1].as_ref().unwrap();
+
+        let c1_obj = heap.get(c1_ref).unwrap();
+        let leaf_ref = c1_obj.slots[0].as_ref().unwrap();
+        let leaf_obj = heap.get(leaf_ref).unwrap();
+        assert_eq!(leaf_obj.slots[0], Value::I64(42));
+
+        let c2_obj = heap.get(c2_ref).unwrap();
+        assert_eq!(c2_obj.slots[0], Value::I64(99));
+    }
+
+    #[test]
+    fn test_heap_bytes_allocated_consistency() {
+        let mut heap = Heap::new();
+
+        let r1 = heap
+            .alloc_slots(vec![Value::I64(1), Value::I64(2)])
+            .unwrap();
+        let _r2 = heap.alloc_slots(vec![Value::I64(3)]).unwrap();
+        let r3 = heap.alloc_typed_array(4, ElemKind::I64).unwrap();
+
+        let before_gc_bytes = heap.bytes_allocated();
+        assert!(before_gc_bytes > 0);
+
+        // GC: keep r1 and r3, drop r2
+        heap.collect(&[Value::Ref(r1), Value::Ref(r3)]);
+
+        let after_gc_bytes = heap.bytes_allocated();
+        // After GC, bytes_allocated should decrease (r2 was freed)
+        assert!(after_gc_bytes < before_gc_bytes);
+        // bytes_allocated should still be positive (two objects remain)
+        assert!(after_gc_bytes > 0);
+    }
 }


### PR DESCRIPTION
## Summary

- GCユニットテストを12件追加（大量割り当て、循環参照、ヒープ整合性検証）
- codegenユニットテストを40件追加（各種式・文・エッジケース）

### GC テスト
- **大量割り当て**: 500オブジェクト割り当て後のGCトリガー、GCしきい値での動作、混合型の大量割り当て
- **循環参照**: 2ノードサイクル、3ノードサイクル、typed ref array経由のサイクル、自己参照、到達不能サイクルの回収
- **ヒープ整合性**: GC後のデータ保持、複数GCサイクル後の整合性、オブジェクトグラフの完全性、`bytes_allocated`の一貫性

### codegen テスト
- **リテラル**: bool, float, nil, string, 複数string
- **演算子**: 単項(否定, NOT), 二項(四則演算, 比較, ビット演算), 短絡評価(&&, ||)
- **文**: let, 代入, if/else, while, return(値あり/void), throw, try/catch, break/continue, 式文のDrop
- **構造**: 配列リテラル, 構造体リテラル, 複数パラメータ関数
- **エッジケース**: 5段ネストif, ネストwhileループ, 50ローカル変数の大関数, 複数関数定義, 再帰関数, 深いネスト式, if-elseとループの組み合わせ

## Test plan
- [x] `cargo fmt` — フォーマット確認
- [x] `cargo check` — コンパイル確認
- [x] `cargo test -- heap::tests codegen::tests` — 全89テストpass
- [x] `cargo clippy` — lint通過

Closes #285

🤖 Generated with [Claude Code](https://claude.com/claude-code)