### PR TITLE
feat(stdlib): 文字列操作関数の拡充

### DIFF
--- a/std/prelude.mc
+++ b/std/prelude.mc
@@ -1413,6 +1413,128 @@ fun str_index_of(haystack: string, needle: string) -> int {
     return -1;
 }
 
+// Check if a string starts with the given prefix.
+fun starts_with(s: string, prefix: string) -> bool {
+    let s_len = len(s);
+    let p_len = len(prefix);
+    if p_len > s_len {
+        return false;
+    }
+    let i = 0;
+    while i < p_len {
+        if s[i] != prefix[i] {
+            return false;
+        }
+        i = i + 1;
+    }
+    return true;
+}
+
+// Check if a string ends with the given suffix.
+fun ends_with(s: string, suffix: string) -> bool {
+    let s_len = len(s);
+    let sf_len = len(suffix);
+    if sf_len > s_len {
+        return false;
+    }
+    let offset = s_len - sf_len;
+    let i = 0;
+    while i < sf_len {
+        if s[offset + i] != suffix[i] {
+            return false;
+        }
+        i = i + 1;
+    }
+    return true;
+}
+
+// Extract a substring from start (inclusive) to end (exclusive).
+// Clamps indices to valid range.
+fun substring(s: string, start: int, end: int) -> string {
+    let s_len = len(s);
+    // Clamp indices
+    if start < 0 { start = 0; }
+    if end > s_len { end = s_len; }
+    if start >= end {
+        return "";
+    }
+    let new_len = end - start;
+    let s_ptr: ptr<char> = s.data;
+    let data: ptr<char> = __alloc_heap(new_len);
+    let i = 0;
+    while i < new_len {
+        data[i] = s_ptr[start + i];
+        i = i + 1;
+    }
+    return __alloc_string(data, new_len);
+}
+
+// Remove leading and trailing ASCII whitespace (space, tab, newline, carriage return).
+fun trim(s: string) -> string {
+    let s_len = len(s);
+    if s_len == 0 {
+        return "";
+    }
+    // Find first non-whitespace
+    let start = 0;
+    while start < s_len && (s[start] == 32 || s[start] == 9 || s[start] == 10 || s[start] == 13) {
+        start = start + 1;
+    }
+    if start == s_len {
+        return "";
+    }
+    // Find last non-whitespace
+    let end = s_len;
+    while end > start && (s[end - 1] == 32 || s[end - 1] == 9 || s[end - 1] == 10 || s[end - 1] == 13) {
+        end = end - 1;
+    }
+    return substring(s, start, end);
+}
+
+// Convert ASCII lowercase letters to uppercase.
+fun to_upper(s: string) -> string {
+    let s_len = len(s);
+    if s_len == 0 {
+        return "";
+    }
+    let s_ptr: ptr<char> = s.data;
+    let data: ptr<char> = __alloc_heap(s_len);
+    let i = 0;
+    while i < s_len {
+        let c = s_ptr[i];
+        // 'a' = 97, 'z' = 122
+        if c >= 97 && c <= 122 {
+            data[i] = c - 32;
+        } else {
+            data[i] = c;
+        }
+        i = i + 1;
+    }
+    return __alloc_string(data, s_len);
+}
+
+// Convert ASCII uppercase letters to lowercase.
+fun to_lower(s: string) -> string {
+    let s_len = len(s);
+    if s_len == 0 {
+        return "";
+    }
+    let s_ptr: ptr<char> = s.data;
+    let data: ptr<char> = __alloc_heap(s_len);
+    let i = 0;
+    while i < s_len {
+        let c = s_ptr[i];
+        // 'A' = 65, 'Z' = 90
+        if c >= 65 && c <= 90 {
+            data[i] = c + 32;
+        } else {
+            data[i] = c;
+        }
+        i = i + 1;
+    }
+    return __alloc_string(data, s_len);
+}
+
 // ============================================================================
 // Array Functions (fixed-length array using heap intrinsics)
 // ============================================================================
@@ -1543,6 +1665,92 @@ impl<T> Vec<T> {
 }
 
 // Associated functions for vec<T> (syntax sugar for Vec<T>)
+
+// ============================================================================
+// String Functions (depending on Vec<T>)
+// ============================================================================
+
+// Split a string by a separator, returning a Vec of strings.
+fun split(s: string, sep: string) -> Vec<string> {
+    let s_len = len(s);
+    let sep_len = len(sep);
+
+    if sep_len == 0 {
+        // Split into individual characters
+        let result: Vec<string> = Vec<string> { data: __null_ptr(), len: 0, cap: 0 };
+        let i = 0;
+        while i < s_len {
+            result.push(substring(s, i, i + 1));
+            i = i + 1;
+        }
+        return result;
+    }
+
+    let result: Vec<string> = Vec<string> { data: __null_ptr(), len: 0, cap: 0 };
+    let start = 0;
+    while start <= s_len {
+        // Find next occurrence of separator
+        let idx = str_index_of(substring(s, start, s_len), sep);
+        if idx == -1 {
+            // No more separators: add the rest
+            result.push(substring(s, start, s_len));
+            start = s_len + 1;
+        } else {
+            result.push(substring(s, start, start + idx));
+            start = start + idx + sep_len;
+        }
+    }
+    return result;
+}
+
+// Replace all occurrences of old with new_str in s.
+fun replace(s: string, old: string, new_str: string) -> string {
+    let old_len = len(old);
+    if old_len == 0 {
+        return s;
+    }
+    let parts = split(s, old);
+    let n = parts.len;
+    if n <= 1 {
+        return s;
+    }
+    // Join parts with new_str
+    let new_len = len(new_str);
+    let total = 0;
+    let i = 0;
+    while i < n {
+        total = total + len(parts[i]);
+        i = i + 1;
+    }
+    total = total + new_len * (n - 1);
+
+    let data: ptr<char> = __alloc_heap(total);
+    let off = 0;
+    i = 0;
+    while i < n {
+        let part = parts[i];
+        let part_ptr: ptr<char> = part.data;
+        let part_len = part.len;
+        let j = 0;
+        while j < part_len {
+            data[off] = part_ptr[j];
+            off = off + 1;
+            j = j + 1;
+        }
+        if i < n - 1 {
+            let ns_ptr: ptr<char> = new_str.data;
+            j = 0;
+            while j < new_len {
+                data[off] = ns_ptr[j];
+                off = off + 1;
+                j = j + 1;
+            }
+        }
+        i = i + 1;
+    }
+    return __alloc_string(data, total);
+}
+
 // ============================================================================
 // Map Functions (HashMap implementation using chaining)
 // ============================================================================

--- a/std/prelude_test.mc
+++ b/std/prelude_test.mc
@@ -327,3 +327,140 @@ fun _test_sort_float_random() {
     _assert_sorted_float(v, "sort_float random seed=42");
     assert_eq(v.len(), 100, "length should be preserved");
 }
+
+// ============================================================================
+// String Functions Tests
+// ============================================================================
+
+// starts_with tests
+fun _test_starts_with_true() {
+    assert_eq_bool(starts_with("hello world", "hello"), true, "starts_with 'hello'");
+    assert_eq_bool(starts_with("hello", "hello"), true, "starts_with exact match");
+    assert_eq_bool(starts_with("hello", ""), true, "starts_with empty prefix");
+    assert_eq_bool(starts_with("", ""), true, "empty starts_with empty");
+}
+
+fun _test_starts_with_false() {
+    assert_eq_bool(starts_with("hello world", "world"), false, "does not start with 'world'");
+    assert_eq_bool(starts_with("hello", "helloo"), false, "prefix longer than string");
+    assert_eq_bool(starts_with("", "a"), false, "empty does not start with 'a'");
+}
+
+// ends_with tests
+fun _test_ends_with_true() {
+    assert_eq_bool(ends_with("hello world", "world"), true, "ends_with 'world'");
+    assert_eq_bool(ends_with("hello", "hello"), true, "ends_with exact match");
+    assert_eq_bool(ends_with("hello", ""), true, "ends_with empty suffix");
+    assert_eq_bool(ends_with("", ""), true, "empty ends_with empty");
+}
+
+fun _test_ends_with_false() {
+    assert_eq_bool(ends_with("hello world", "hello"), false, "does not end with 'hello'");
+    assert_eq_bool(ends_with("hello", "helloo"), false, "suffix longer than string");
+    assert_eq_bool(ends_with("", "a"), false, "empty does not end with 'a'");
+}
+
+// substring tests
+fun _test_substring_basic() {
+    assert_eq_str(substring("hello world", 0, 5), "hello", "substring 0..5");
+    assert_eq_str(substring("hello world", 6, 11), "world", "substring 6..11");
+    assert_eq_str(substring("hello world", 0, 11), "hello world", "substring full");
+    assert_eq_str(substring("hello", 1, 4), "ell", "substring 1..4");
+}
+
+fun _test_substring_edge_cases() {
+    assert_eq_str(substring("hello", 0, 0), "", "substring empty range");
+    assert_eq_str(substring("hello", 5, 5), "", "substring at end");
+    assert_eq_str(substring("hello", 3, 2), "", "substring reversed range");
+    assert_eq_str(substring("hello", -1, 3), "hel", "substring clamp negative start");
+    assert_eq_str(substring("hello", 0, 100), "hello", "substring clamp end beyond length");
+    assert_eq_str(substring("", 0, 0), "", "substring of empty string");
+}
+
+// trim tests
+fun _test_trim_basic() {
+    assert_eq_str(trim("  hello  "), "hello", "trim spaces");
+    assert_eq_str(trim("hello"), "hello", "trim no whitespace");
+    assert_eq_str(trim("  hello"), "hello", "trim leading spaces");
+    assert_eq_str(trim("hello  "), "hello", "trim trailing spaces");
+}
+
+fun _test_trim_whitespace_types() {
+    assert_eq_str(trim(""), "", "trim empty string");
+    assert_eq_str(trim("   "), "", "trim only spaces");
+}
+
+// to_upper tests
+fun _test_to_upper() {
+    assert_eq_str(to_upper("hello"), "HELLO", "to_upper basic");
+    assert_eq_str(to_upper("Hello World"), "HELLO WORLD", "to_upper mixed case");
+    assert_eq_str(to_upper("HELLO"), "HELLO", "to_upper already upper");
+    assert_eq_str(to_upper(""), "", "to_upper empty");
+    assert_eq_str(to_upper("123abc"), "123ABC", "to_upper with numbers");
+}
+
+// to_lower tests
+fun _test_to_lower() {
+    assert_eq_str(to_lower("HELLO"), "hello", "to_lower basic");
+    assert_eq_str(to_lower("Hello World"), "hello world", "to_lower mixed case");
+    assert_eq_str(to_lower("hello"), "hello", "to_lower already lower");
+    assert_eq_str(to_lower(""), "", "to_lower empty");
+    assert_eq_str(to_lower("123ABC"), "123abc", "to_lower with numbers");
+}
+
+// split tests
+fun _test_split_basic() {
+    let parts = split("a,b,c", ",");
+    assert_eq(parts.len, 3, "split ',' count");
+    assert_eq_str(parts[0], "a", "split part 0");
+    assert_eq_str(parts[1], "b", "split part 1");
+    assert_eq_str(parts[2], "c", "split part 2");
+}
+
+fun _test_split_no_match() {
+    let parts = split("hello", ",");
+    assert_eq(parts.len, 1, "split no match count");
+    assert_eq_str(parts[0], "hello", "split no match part");
+}
+
+fun _test_split_multi_char_sep() {
+    let parts = split("a::b::c", "::");
+    assert_eq(parts.len, 3, "split '::' count");
+    assert_eq_str(parts[0], "a", "split '::' part 0");
+    assert_eq_str(parts[1], "b", "split '::' part 1");
+    assert_eq_str(parts[2], "c", "split '::' part 2");
+}
+
+fun _test_split_empty_parts() {
+    let parts = split(",a,,b,", ",");
+    assert_eq(parts.len, 5, "split with empty parts count");
+    assert_eq_str(parts[0], "", "split empty first");
+    assert_eq_str(parts[1], "a", "split a");
+    assert_eq_str(parts[2], "", "split empty middle");
+    assert_eq_str(parts[3], "b", "split b");
+    assert_eq_str(parts[4], "", "split empty last");
+}
+
+fun _test_split_empty_sep() {
+    let parts = split("abc", "");
+    assert_eq(parts.len, 3, "split empty sep count");
+    assert_eq_str(parts[0], "a", "split char a");
+    assert_eq_str(parts[1], "b", "split char b");
+    assert_eq_str(parts[2], "c", "split char c");
+}
+
+// replace tests
+fun _test_replace_basic() {
+    assert_eq_str(replace("hello world", "world", "moca"), "hello moca", "replace basic");
+    assert_eq_str(replace("aaa", "a", "bb"), "bbbbbb", "replace all occurrences");
+    assert_eq_str(replace("hello", "xyz", "abc"), "hello", "replace no match");
+}
+
+fun _test_replace_empty() {
+    assert_eq_str(replace("hello", "", "x"), "hello", "replace empty old returns original");
+    assert_eq_str(replace("hello world", "o", ""), "hell wrld", "replace with empty new");
+}
+
+fun _test_replace_multi_char() {
+    assert_eq_str(replace("foo bar foo", "foo", "baz"), "baz bar baz", "replace multi-char");
+}


### PR DESCRIPTION
## Summary

- 標準ライブラリに実用的な文字列操作関数を7種追加
- 全関数についてユニットテストを追加

### 追加した関数

| 関数 | シグネチャ | 説明 |
|------|-----------|------|
| `starts_with` | `(s: string, prefix: string) -> bool` | 前方一致判定 |
| `ends_with` | `(s: string, suffix: string) -> bool` | 後方一致判定 |
| `substring` | `(s: string, start: int, end: int) -> string` | 部分文字列取得（範囲クランプ付き） |
| `trim` | `(s: string) -> string` | 前後の空白除去（space, tab, newline, CR） |
| `to_upper` | `(s: string) -> string` | ASCII小文字→大文字変換 |
| `to_lower` | `(s: string) -> string` | ASCII大文字→小文字変換 |
| `split` | `(s: string, sep: string) -> Vec<string>` | 区切り文字による分割 |
| `replace` | `(s: string, old: string, new_str: string) -> string` | 全置換 |

### 実装上の注意点

- hostcall不使用、全て純粋なmocaコードで実装
- `__alloc_heap` で文字列データを確保する際は `ptr<char>` 型注釈が必須（codegen がElemKind::U8を推論するため）
- `split` と `replace` はVec依存のため、Vec定義の後に配置

## Test plan
- [x] `cargo fmt` — フォーマット確認
- [x] `cargo check` — コンパイル確認
- [x] `cargo test` — 全テストpass（398 unit + 19 snapshot）
- [x] `cargo clippy` — lint通過
- [x] `moca lint std/prelude.mc` — 警告なし
- [x] 手動テスト: 全関数の動作確認済み

Closes #284

🤖 Generated with [Claude Code](https://claude.com/claude-code)