### PR TITLE
feat(lint): Lambda の未使用パラメータに対する unused-variable 警告を追加

### DIFF
--- a/src/compiler/linter.rs
+++ b/src/compiler/linter.rs
@@ -1,6 +1,6 @@
 use std::collections::{HashMap, HashSet};
 
-use crate::compiler::ast::{Block, Expr, FnDef, Item, Program, Statement};
+use crate::compiler::ast::{Block, Expr, FnDef, Item, Param, Program, Statement};
 use crate::compiler::lexer::Span;
 use crate::compiler::types::{Type, TypeAnnotation};
 
@@ -268,9 +268,9 @@ fn lint_expr(expr: &Expr, rules: &[Box<dyn LintRule>], diagnostics: &mut Vec<Dia
             }
             lint_expr(expr, rules, diagnostics);
         }
-        Expr::Lambda { body, .. } => {
+        Expr::Lambda { params, body, .. } => {
             lint_block(body, rules, diagnostics);
-            check_unused_variables_in_stmts(&body.statements, diagnostics);
+            check_unused_variables_in_stmts_with_params(params, &body.statements, diagnostics);
         }
         Expr::CallExpr { callee, args, .. } => {
             lint_expr(callee, rules, diagnostics);
@@ -556,10 +556,26 @@ impl LintRule for RedundantAsDyn {
 /// Collects all variable declarations and all identifier usages,
 /// then reports declarations that are never referenced.
 fn check_unused_variables_in_stmts(stmts: &[Statement], diagnostics: &mut Vec<Diagnostic>) {
+    check_unused_variables_in_stmts_with_params(&[], stmts, diagnostics);
+}
+
+/// Check for unused variables in a list of statements, also treating the given
+/// params (e.g. lambda parameters) as declarations.
+fn check_unused_variables_in_stmts_with_params(
+    params: &[Param],
+    stmts: &[Statement],
+    diagnostics: &mut Vec<Diagnostic>,
+) {
     // Map from variable name to (span, declaration_order) for reporting
     let mut declarations: HashMap<String, (Span, usize)> = HashMap::new();
     let mut used_names: HashSet<String> = HashSet::new();
     let mut order = 0;
+
+    // Add params as declarations
+    for param in params {
+        declarations.insert(param.name.clone(), (param.span, order));
+        order += 1;
+    }
 
     for stmt in stmts {
         collect_declarations_stmt(stmt, &mut declarations, &mut order);

--- a/tests/snapshots/lint/unused_lambda_param.lint
+++ b/tests/snapshots/lint/unused_lambda_param.lint
@@ -1,0 +1,4 @@
+unused-variable:2:13
+unused-variable:14:21
+unused-variable:18:13
+unused-variable:18:21

--- a/tests/snapshots/lint/unused_lambda_param.mc
+++ b/tests/snapshots/lint/unused_lambda_param.mc
@@ -1,0 +1,19 @@
+// Unused lambda parameter — should warn
+let f = fun(x: int) -> int { return 42; };
+print(f(1));
+
+// Used lambda parameter — no warning
+let g = fun(y: int) -> int { return y + 1; };
+print(g(1));
+
+// _ prefix suppresses warning
+let h = fun(_z: int) -> int { return 0; };
+print(h(1));
+
+// Multiple params, some unused
+let m = fun(a: int, b: int) -> int { return a; };
+print(m(1, 2));
+
+// All params unused
+let n = fun(p: int, q: int) -> int { return 99; };
+print(n(1, 2));


### PR DESCRIPTION
## Summary

- `unused-variable` lint がラムダのパラメータを検出対象にしていなかった問題を修正
- `check_unused_variables_in_stmts` をリファクタリングし、パラメータも宣言として追跡する `check_unused_variables_in_stmts_with_params` を追加
- `_` プレフィックスによる警告抑制にも対応（既存の関数パラメータと同じルール）

## Test plan

- [x] 新規テスト `tests/snapshots/lint/unused_lambda_param.mc` + `.lint` を追加
  - 未使用パラメータ → 警告
  - 使用済みパラメータ → 警告なし
  - `_` プレフィックス → 警告なし
  - 複数パラメータの一部のみ未使用 → 該当パラメータのみ警告
  - 全パラメータ未使用 → 全て警告
- [x] 既存の lint テストが全てパス
- [x] `cargo fmt`, `cargo check`, `cargo test`, `cargo clippy` 全てパス

Closes #292

🤖 Generated with [Claude Code](https://claude.ai/code)